### PR TITLE
docs: add configuration guide with example and field descriptions

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,328 @@
+# POP Configuration Guide
+
+POP loads configuration from four separate YAML files at startup, all located in `/etc/dnstapir/`:
+
+| File | Purpose |
+|------|---------|
+| `dnstapir-pop.yaml` | Main config: logging, services, API/DNS/bootstrap servers, keystore |
+| `pop-sources.yaml` | Intelligence sources (MQTT, file, RPZ zone transfer) |
+| `pop-outputs.yaml` | RPZ downstream outputs |
+| `pop-policy.yaml` | Policy rules for allow/deny/doubtlist decisions |
+
+---
+
+## dnstapir-pop.yaml
+
+```yaml
+log:
+  file: "/var/log/dnstapir/pop.log"
+  verbose: false
+  debug: false
+
+services:
+  rpz:
+    zonename: "rpz.example.com."
+    serialcache: "/var/cache/dnstapir/pop-serial.yaml"
+  reaper:
+    interval: 3600
+
+apiserver:
+  active: true
+  name: "pop-api"
+  key: "your-api-key"
+  addresses:
+    - "127.0.0.1:8080"
+  tlsaddresses:
+    - "0.0.0.0:8443"
+
+dnsengine:
+  active: true
+  name: "pop-dns"
+  addresses:
+    - "127.0.0.1:53"
+  logfile: "/var/log/dnstapir/pop-dns.log"
+
+bootstrapserver:
+  active: false
+  name: "pop-bootstrap"
+  addresses:
+    - "127.0.0.1:9090"
+  tlsaddresses:
+    - "0.0.0.0:9443"
+  logfile: "/var/log/dnstapir/pop-bootstrap.log"
+
+keystore:
+  path: "/etc/dnstapir/keystore.json"
+```
+
+### Field reference
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `log.file` | yes | Log file path |
+| `log.verbose` | yes | Enable verbose logging |
+| `log.debug` | yes | Enable debug logging |
+| `services.rpz.zonename` | yes | RPZ zone name served to downstream resolvers |
+| `services.rpz.serialcache` | yes | File where the current RPZ serial is persisted across restarts |
+| `services.reaper.interval` | yes | Interval in seconds for the cleanup (reaper) goroutine |
+| `apiserver.active` | yes | Enable the REST API server |
+| `apiserver.name` | yes | API server identifier |
+| `apiserver.key` | yes | API authentication key |
+| `apiserver.addresses` | yes | HTTP listen addresses (list) |
+| `apiserver.tlsaddresses` | yes | HTTPS listen addresses (list) |
+| `dnsengine.active` | yes | Enable the DNS engine |
+| `dnsengine.name` | yes | DNS engine identifier |
+| `dnsengine.addresses` | yes | DNS listen addresses (list) |
+| `dnsengine.logfile` | yes | DNS engine log file path |
+| `bootstrapserver.active` | yes | Enable the bootstrap server |
+| `bootstrapserver.name` | yes | Bootstrap server identifier |
+| `bootstrapserver.addresses` | yes | HTTP listen addresses (list) |
+| `bootstrapserver.tlsaddresses` | yes | HTTPS listen addresses (list) |
+| `bootstrapserver.logfile` | no | Bootstrap server log file path |
+| `keystore.path` | yes | Path to the keystore file (must already exist) |
+
+---
+
+## pop-sources.yaml
+
+Each entry under `sources` defines one intelligence feed. The `source` field controls how the data is fetched; the `type` field controls which list the data is loaded into.
+
+```yaml
+sources:
+  # MQTT-based intelligence feed
+  tapir-mqtt-feed:
+    active: true
+    name: "tapir-mqtt-feed"
+    description: "DNS TAPIR MQTT intelligence feed"
+    type: "doubtlist"        # List to load into: allowlist, denylist, or doubtlist
+    format: "json"           # Wire format: json
+    source: "mqtt"           # Fetch method: mqtt, file, or xfr
+    topic: "tapir/feed/blocklist"
+    validatorkey: "/etc/dnstapir/validator.key"
+    bootstrap:
+      - "https://bootstrap.example.com/feed"
+    bootstrapurl: "https://bootstrap.example.com"
+    bootstrapkey: "/etc/dnstapir/bootstrap.key"
+
+  # Local domain list (plain text, one domain per line)
+  local-allowlist:
+    active: true
+    name: "local-allowlist"
+    description: "Locally managed allowlist"
+    type: "allowlist"
+    format: "domains"        # File format: domains, csv, or dawg
+    source: "file"
+    filename: "/etc/dnstapir/allowlist.txt"
+    immutable: false         # If true, the list is never updated at runtime
+
+  # RPZ zone transfer feed
+  upstream-rpz:
+    active: true
+    name: "upstream-rpz"
+    description: "Upstream RPZ denylist via zone transfer"
+    type: "denylist"
+    format: "rpz"
+    source: "xfr"
+    upstream: "192.0.2.1:53"
+    zone: "blocklist.example.com."
+```
+
+### Field reference
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `active` | yes | Enable this source |
+| `name` | yes | Source identifier |
+| `description` | yes | Human-readable description |
+| `type` | yes | Target list: `allowlist`, `denylist`, or `doubtlist` |
+| `format` | yes | Data format. For `source: mqtt`: `json`. For `source: file`: `domains`, `csv`, or `dawg`. For `source: xfr`: `rpz` |
+| `source` | yes | Fetch method: `mqtt`, `file`, or `xfr` |
+| `topic` | required when `source: mqtt` | MQTT topic to subscribe to |
+| `validatorkey` | no | Path to the key used to verify signed MQTT messages |
+| `bootstrap` | no | List of bootstrap server URLs for initial data load (`source: mqtt` only) |
+| `bootstrapurl` | no | Bootstrap server base URL (`source: mqtt` only) |
+| `bootstrapkey` | no | Path to the bootstrap authentication key (`source: mqtt` only) |
+| `filename` | required when `source: file` | Path to the local file |
+| `immutable` | no | If `true`, the list is never refreshed at runtime (default: `false`) |
+| `upstream` | required when `source: xfr` | Upstream DNS server address `host:port` for zone transfer |
+| `zone` | required when `source: xfr` | Zone name to transfer |
+
+**Note on `type: allowlist` with DAWG format:** DAWG files are only supported for `type: allowlist`.
+
+---
+
+## pop-outputs.yaml
+
+Outputs define downstream DNS resolvers that receive DNS NOTIFY messages and can perform DNS AXFR/IXFR zone transfers.
+
+```yaml
+outputs:
+  primary-resolver:
+    active: true
+    name: "primary-resolver"
+    description: "Primary downstream DNS resolver"
+    type: "doubtlist"
+    format: "rpz"
+    downstream: "192.0.2.10:53"
+```
+
+### Field reference
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `active` | yes | Enable this output |
+| `name` | yes | Output identifier |
+| `description` | yes | Human-readable description |
+| `type` | yes | Source list type this output is derived from |
+| `format` | yes | Output format: `rpz` (currently the only supported format) |
+| `downstream` | yes | Downstream resolver address `host:port` to send DNS NOTIFY to |
+
+---
+
+## pop-policy.yaml
+
+Policy rules determine what RPZ action is applied to names found in each list.
+
+```yaml
+policy:
+  logfile: "/var/log/dnstapir/pop-policy.log"
+  allowlist:
+    action: "allowlist"
+  denylist:
+    action: "nxdomain"
+  doubtlist:
+    numsources:
+      limit: 3
+      action: "nxdomain"
+    numtapirtags:
+      limit: 2
+      action: "drop"
+    denytapir:
+      tags:
+        - "malware"
+        - "phishing"
+      action: "drop"
+```
+
+### Field reference
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `policy.logfile` | no | Policy decision log file path |
+| `policy.allowlist.action` | yes | Action for allowlisted names |
+| `policy.denylist.action` | yes | Action for denylisted names |
+| `policy.doubtlist.numsources.limit` | yes | Block if a name appears in this many or more doubtlist sources |
+| `policy.doubtlist.numsources.action` | yes | Action when `numsources.limit` is reached |
+| `policy.doubtlist.numtapirtags.limit` | yes | Block if a name carries this many or more TAPIR tags |
+| `policy.doubtlist.numtapirtags.action` | yes | Action when `numtapirtags.limit` is reached |
+| `policy.doubtlist.denytapir.tags` | yes | Block if a name carries any of these TAPIR tags |
+| `policy.doubtlist.denytapir.action` | yes | Action when a tag in `denytapir.tags` is matched |
+
+### Valid action values
+
+| Value | RPZ effect |
+|-------|-----------|
+| `allowlist` or `passthru` | `rpz-passthru.` — allow the name through |
+| `nxdomain` | `.` — return NXDOMAIN |
+| `nodata` | `*.` — return NODATA |
+| `drop` | `rpz-drop.` — silently drop the query |
+| `redirect` | redirect (target TBD in upstream config) |
+
+### Policy examples
+
+**Strict — block anything doubtful:**
+```yaml
+policy:
+  allowlist:
+    action: "allowlist"
+  denylist:
+    action: "nxdomain"
+  doubtlist:
+    numsources:
+      limit: 1        # Block if seen in even one source
+      action: "nxdomain"
+    numtapirtags:
+      limit: 1        # Block if any TAPIR tag present
+      action: "nxdomain"
+    denytapir:
+      tags:
+        - "malware"
+        - "phishing"
+        - "botnet"
+      action: "nxdomain"
+```
+
+**Permissive — only block high-confidence threats:**
+```yaml
+policy:
+  allowlist:
+    action: "allowlist"
+  denylist:
+    action: "drop"
+  doubtlist:
+    numsources:
+      limit: 5        # Require corroboration from multiple sources
+      action: "drop"
+    numtapirtags:
+      limit: 3        # Require several TAPIR tags before blocking
+      action: "drop"
+    denytapir:
+      tags:
+        - "malware"
+      action: "nxdomain"
+```
+
+**Silent drop — hide blocking from clients:**
+```yaml
+policy:
+  allowlist:
+    action: "allowlist"
+  denylist:
+    action: "drop"
+  doubtlist:
+    numsources:
+      limit: 2
+      action: "drop"
+    numtapirtags:
+      limit: 2
+      action: "drop"
+    denytapir:
+      tags:
+        - "malware"
+        - "phishing"
+      action: "drop"
+```
+
+---
+
+## List file formats
+
+File-based sources (`source: file`) support three formats, set via the `format` field.
+
+### domains
+
+Plain text, one fully-qualified domain name per line. Lines are read as-is and converted to FQDN (trailing dot appended if missing).
+
+```
+example.com
+malicious.example.org
+blocked.test.
+```
+
+### csv
+
+CSV file with a header row (skipped) and the domain name in the **second column** (index 1).
+
+```
+id,domain,category
+1,malicious.example.com,malware
+2,phishing.example.org,phishing
+```
+
+### dawg
+
+A pre-built binary [DAWG](https://github.com/smhanov/dawg) (Directed Acyclic Word Graph) file. DAWG is a compact, read-only data structure optimised for large allowlists.
+
+- Only supported for `type: allowlist`
+- Build a DAWG file from a sorted domain list using the `tapir` CLI tool
+- The file is loaded directly at startup; runtime updates are not supported

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -137,15 +137,15 @@ sources:
 | `type` | yes | Target list: `allowlist`, `denylist`, or `doubtlist` |
 | `format` | yes | Data format. For `source: mqtt`: `json`. For `source: file`: `domains`, `csv`, or `dawg`. For `source: xfr`: `rpz` |
 | `source` | yes | Fetch method: `mqtt`, `file`, or `xfr` |
-| `topic` | no | MQTT topic to subscribe to (`source: mqtt` only) |
+| `topic` | required when `source: mqtt` | MQTT topic to subscribe to |
 | `validatorkey` | no | Path to the key used to verify signed MQTT messages |
 | `bootstrap` | no | List of bootstrap server URLs for initial data load (`source: mqtt` only) |
-| `bootstrapurl` | no | Bootstrap server base URL |
-| `bootstrapkey` | no | Path to the bootstrap authentication key |
-| `filename` | no | Path to the local file (`source: file` only) |
+| `bootstrapurl` | no | Bootstrap server base URL (`source: mqtt` only) |
+| `bootstrapkey` | no | Path to the bootstrap authentication key (`source: mqtt` only) |
+| `filename` | required when `source: file` | Path to the local file |
 | `immutable` | no | If `true`, the list is never refreshed at runtime (default: `false`) |
-| `upstream` | no | Upstream DNS server address `host:port` for zone transfer (`source: xfr` only) |
-| `zone` | no | Zone name to transfer (`source: xfr` only) |
+| `upstream` | required when `source: xfr` | Upstream DNS server address `host:port` for zone transfer |
+| `zone` | required when `source: xfr` | Zone name to transfer |
 
 **Note on `type: allowlist` with DAWG format:** DAWG files are only supported for `type: allowlist`.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -227,3 +227,102 @@ policy:
 | `nodata` | `*.` — return NODATA |
 | `drop` | `rpz-drop.` — silently drop the query |
 | `redirect` | redirect (target TBD in upstream config) |
+
+### Policy examples
+
+**Strict — block anything doubtful:**
+```yaml
+policy:
+  allowlist:
+    action: "allowlist"
+  denylist:
+    action: "nxdomain"
+  doubtlist:
+    numsources:
+      limit: 1        # Block if seen in even one source
+      action: "nxdomain"
+    numtapirtags:
+      limit: 1        # Block if any TAPIR tag present
+      action: "nxdomain"
+    denytapir:
+      tags:
+        - "malware"
+        - "phishing"
+        - "botnet"
+      action: "nxdomain"
+```
+
+**Permissive — only block high-confidence threats:**
+```yaml
+policy:
+  allowlist:
+    action: "allowlist"
+  denylist:
+    action: "drop"
+  doubtlist:
+    numsources:
+      limit: 5        # Require corroboration from multiple sources
+      action: "drop"
+    numtapirtags:
+      limit: 3        # Require several TAPIR tags before blocking
+      action: "drop"
+    denytapir:
+      tags:
+        - "malware"
+      action: "nxdomain"
+```
+
+**Silent drop — hide blocking from clients:**
+```yaml
+policy:
+  allowlist:
+    action: "allowlist"
+  denylist:
+    action: "drop"
+  doubtlist:
+    numsources:
+      limit: 2
+      action: "drop"
+    numtapirtags:
+      limit: 2
+      action: "drop"
+    denytapir:
+      tags:
+        - "malware"
+        - "phishing"
+      action: "drop"
+```
+
+---
+
+## List file formats
+
+File-based sources (`source: file`) support three formats, set via the `format` field.
+
+### domains
+
+Plain text, one fully-qualified domain name per line. Lines are read as-is and converted to FQDN (trailing dot appended if missing).
+
+```
+example.com
+malicious.example.org
+blocked.test.
+```
+
+### csv
+
+CSV file with a header row (skipped) and the domain name in the **second column** (index 1).
+
+```
+id,domain,category
+1,malicious.example.com,malware
+2,phishing.example.org,phishing
+```
+
+### dawg
+
+A pre-built binary [DAWG](https://github.com/smhanov/dawg) (Directed Acyclic Word Graph) file. DAWG is a compact, read-only data structure optimised for large allowlists.
+
+- Only supported for `type: allowlist`
+- Build a DAWG file from a sorted domain list using the `tapir` CLI tool
+- The file is loaded directly at startup; runtime updates are not supported

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # POP Configuration Guide
 
-POP uses a YAML configuration file. Below is a complete example with explanations for each field.
+POP uses a YAML configuration file. Below is a complete example with explanations for key fields.
 
 ## Example Configuration
 
@@ -12,7 +12,7 @@ log:
 
 services:
   rpz:
-    zonename: "rpz.example.com."   # RPZ zone name
+    zonename: "rpz.example.com."                # RPZ zone name
     serialcache: "/var/cache/pop/serial.cache"  # Path to serial cache file
   reaper:
     interval: 3600   # Cleanup interval in seconds
@@ -34,13 +34,13 @@ dnsengine:
   logfile: "/var/log/pop-dns.log"
 
 bootstrapserver:
-  active: false
+  active: false                # Set to true to enable bootstrap server
   name: "pop-bootstrap"
-  addresses:
+  addresses:                   # HTTP listen addresses
     - "127.0.0.1:9090"
-  tlsaddresses:
+  tlsaddresses:                # HTTPS listen addresses
     - "0.0.0.0:9443"
-  logfile: "/var/log/pop-bootstrap.log"
+  logfile: "/var/log/pop-bootstrap.log"  # Optional log file
 
 keystore:
   path: "/etc/pop/keystore.json"   # Path to keystore file (must exist)
@@ -50,12 +50,12 @@ sources:
     active: true
     name: "example-mqtt-source"
     description: "Example MQTT intelligence source"
-    type: "mqtt"              # Source type: mqtt, file, etc.
-    format: "json"            # Data format
+    type: "mqtt"                   # Source type: mqtt or file
+    format: "json"                 # Data format: json or rpz
     source: "mqtt://broker.example.com"
-    topic: "tapir/feed/blocklist"
+    topic: "tapir/feed/blocklist"  # MQTT topic (mqtt sources only)
     validatorkey: "path/to/validator.key"
-    bootstrap:
+    bootstrap:                     # Bootstrap URLs (optional)
       - "https://bootstrap.example.com/feed"
     bootstrapurl: "https://bootstrap.example.com"
     bootstrapkey: "path/to/bootstrap.key"
@@ -67,24 +67,24 @@ sources:
     type: "file"
     format: "rpz"
     source: "local"
-    filename: "/etc/pop/blocklist.rpz"
-    immutable: false          # If true, source will not be updated
+    filename: "/etc/pop/blocklist.rpz"  # Local file path (file sources only)
+    immutable: false                     # If true, source will not be updated
 
 policy:
-  logfile: "/var/log/pop-policy.log"
+  logfile: "/var/log/pop-policy.log"   # Optional policy log file
   allowlist:
-    action: "accept"          # Action for allowlisted domains: accept
+    action: "accept"          # Action for allowlisted domains
   denylist:
-    action: "drop"            # Action for denylisted domains: drop
+    action: "drop"            # Action for denylisted domains
   doubtlist:
     numsources:
-      limit: 3                # Block if seen in this many sources
+      limit: 3                # Block if domain seen in this many sources
       action: "drop"
     numtapirtags:
-      limit: 2                # Block if has this many TAPIR tags
+      limit: 2                # Block if domain has this many TAPIR tags
       action: "drop"
     denytapir:
-      tags:                   # Block if domain has any of these tags
+      tags:                   # Block if domain has any of these TAPIR tags
         - "malware"
         - "phishing"
       action: "drop"
@@ -92,16 +92,16 @@ policy:
 
 ## Required Fields
 
-All fields marked below are required unless stated otherwise.
+All fields are required unless marked as optional.
 
 | Section | Field | Required | Description |
 |---------|-------|----------|-------------|
 | log | file | ✅ | Log file path |
-| log | verbose | ✅ | Verbose logging toggle |
-| log | debug | ✅ | Debug logging toggle |
+| log | verbose | ✅ | Enable verbose logging |
+| log | debug | ✅ | Enable debug logging |
 | services.rpz | zonename | ✅ | RPZ zone name |
 | services.rpz | serialcache | ✅ | Serial cache file path |
-| services.reaper | interval | ✅ | Reaper interval in seconds |
+| services.reaper | interval | ✅ | Cleanup interval in seconds |
 | apiserver | active | ✅ | Enable API server |
 | apiserver | name | ✅ | API server name |
 | apiserver | key | ✅ | API authentication key |
@@ -111,12 +111,31 @@ All fields marked below are required unless stated otherwise.
 | dnsengine | name | ✅ | DNS engine name |
 | dnsengine | addresses | ✅ | DNS listen addresses |
 | dnsengine | logfile | ✅ | DNS engine log file |
+| bootstrapserver | active | ✅ | Enable bootstrap server |
+| bootstrapserver | name | ✅ | Bootstrap server name |
+| bootstrapserver | addresses | ✅ | HTTP listen addresses |
+| bootstrapserver | tlsaddresses | ✅ | HTTPS listen addresses |
+| bootstrapserver | logfile | ➖ | Log file path (optional) |
 | keystore | path | ✅ | Path to keystore file (must exist) |
 | sources.* | active | ✅ | Enable this source |
 | sources.* | name | ✅ | Source name |
 | sources.* | description | ✅ | Source description |
-| sources.* | type | ✅ | Source type (mqtt, file, etc.) |
-| sources.* | format | ✅ | Data format (json, rpz, etc.) |
+| sources.* | type | ✅ | Source type: `mqtt` or `file` |
+| sources.* | format | ✅ | Data format: `json` or `rpz` |
 | sources.* | source | ✅ | Source connection string |
+| sources.* | topic | ➖ | MQTT topic (mqtt sources only) |
+| sources.* | filename | ➖ | Local file path (file sources only) |
+| sources.* | immutable | ➖ | Prevent source updates (optional, default: false) |
+| sources.* | validatorkey | ➖ | Path to validator key (optional) |
+| sources.* | bootstrap | ➖ | Bootstrap URLs (optional) |
+| sources.* | bootstrapurl | ➖ | Bootstrap server URL (optional) |
+| sources.* | bootstrapkey | ➖ | Bootstrap key path (optional) |
+| policy | logfile | ➖ | Policy log file (optional) |
 | policy.allowlist | action | ✅ | Action for allowlisted domains |
 | policy.denylist | action | ✅ | Action for denylisted domains |
+| policy.doubtlist.numsources | limit | ✅ | Source count threshold |
+| policy.doubtlist.numsources | action | ✅ | Action when threshold exceeded |
+| policy.doubtlist.numtapirtags | limit | ✅ | TAPIR tag count threshold |
+| policy.doubtlist.numtapirtags | action | ✅ | Action when threshold exceeded |
+| policy.doubtlist.denytapir | tags | ✅ | TAPIR tags that trigger denial |
+| policy.doubtlist.denytapir | action | ✅ | Action for matched tags |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,29 +1,38 @@
 # POP Configuration Guide
 
-POP uses a YAML configuration file. Below is a complete example with explanations for key fields.
+POP loads configuration from four separate YAML files at startup, all located in `/etc/dnstapir/`:
 
-## Example Configuration
+| File | Purpose |
+|------|---------|
+| `dnstapir-pop.yaml` | Main config: logging, services, API/DNS/bootstrap servers, keystore |
+| `pop-sources.yaml` | Intelligence sources (MQTT, file, RPZ zone transfer) |
+| `pop-outputs.yaml` | RPZ downstream outputs |
+| `pop-policy.yaml` | Policy rules for allow/deny/doubtlist decisions |
+
+---
+
+## dnstapir-pop.yaml
 
 ```yaml
 log:
-  file: "/var/log/pop.log"    # Path to log file
-  verbose: false               # Enable verbose logging
-  debug: false                 # Enable debug logging
+  file: "/var/log/dnstapir/pop.log"
+  verbose: false
+  debug: false
 
 services:
   rpz:
-    zonename: "rpz.example.com."                # RPZ zone name
-    serialcache: "/var/cache/pop/serial.cache"  # Path to serial cache file
+    zonename: "rpz.example.com."
+    serialcache: "/var/cache/dnstapir/pop-serial.yaml"
   reaper:
-    interval: 3600   # Cleanup interval in seconds
+    interval: 3600
 
 apiserver:
   active: true
   name: "pop-api"
   key: "your-api-key"
-  addresses:                   # HTTP listen addresses
+  addresses:
     - "127.0.0.1:8080"
-  tlsaddresses:                # HTTPS listen addresses
+  tlsaddresses:
     - "0.0.0.0:8443"
 
 dnsengine:
@@ -31,111 +40,190 @@ dnsengine:
   name: "pop-dns"
   addresses:
     - "127.0.0.1:53"
-  logfile: "/var/log/pop-dns.log"
+  logfile: "/var/log/dnstapir/pop-dns.log"
 
 bootstrapserver:
-  active: false                # Set to true to enable bootstrap server
+  active: false
   name: "pop-bootstrap"
-  addresses:                   # HTTP listen addresses
+  addresses:
     - "127.0.0.1:9090"
-  tlsaddresses:                # HTTPS listen addresses
+  tlsaddresses:
     - "0.0.0.0:9443"
-  logfile: "/var/log/pop-bootstrap.log"  # Optional log file
+  logfile: "/var/log/dnstapir/pop-bootstrap.log"
 
 keystore:
-  path: "/etc/pop/keystore.json"   # Path to keystore file (must exist)
+  path: "/etc/dnstapir/keystore.json"
+```
 
+### Field reference
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `log.file` | yes | Log file path |
+| `log.verbose` | yes | Enable verbose logging |
+| `log.debug` | yes | Enable debug logging |
+| `services.rpz.zonename` | yes | RPZ zone name served to downstream resolvers |
+| `services.rpz.serialcache` | yes | File where the current RPZ serial is persisted across restarts |
+| `services.reaper.interval` | yes | Interval in seconds for the cleanup (reaper) goroutine |
+| `apiserver.active` | yes | Enable the REST API server |
+| `apiserver.name` | yes | API server identifier |
+| `apiserver.key` | yes | API authentication key |
+| `apiserver.addresses` | yes | HTTP listen addresses (list) |
+| `apiserver.tlsaddresses` | yes | HTTPS listen addresses (list) |
+| `dnsengine.active` | yes | Enable the DNS engine |
+| `dnsengine.name` | yes | DNS engine identifier |
+| `dnsengine.addresses` | yes | DNS listen addresses (list) |
+| `dnsengine.logfile` | yes | DNS engine log file path |
+| `bootstrapserver.active` | yes | Enable the bootstrap server |
+| `bootstrapserver.name` | yes | Bootstrap server identifier |
+| `bootstrapserver.addresses` | yes | HTTP listen addresses (list) |
+| `bootstrapserver.tlsaddresses` | yes | HTTPS listen addresses (list) |
+| `bootstrapserver.logfile` | no | Bootstrap server log file path |
+| `keystore.path` | yes | Path to the keystore file (must already exist) |
+
+---
+
+## pop-sources.yaml
+
+Each entry under `sources` defines one intelligence feed. The `source` field controls how the data is fetched; the `type` field controls which list the data is loaded into.
+
+```yaml
 sources:
-  example-mqtt-source:
+  # MQTT-based intelligence feed
+  tapir-mqtt-feed:
     active: true
-    name: "example-mqtt-source"
-    description: "Example MQTT intelligence source"
-    type: "mqtt"                   # Source type: mqtt or file
-    format: "json"                 # Data format: json or rpz
-    source: "mqtt://broker.example.com"
-    topic: "tapir/feed/blocklist"  # MQTT topic (mqtt sources only)
-    validatorkey: "path/to/validator.key"
-    bootstrap:                     # Bootstrap URLs (optional)
+    name: "tapir-mqtt-feed"
+    description: "DNS TAPIR MQTT intelligence feed"
+    type: "doubtlist"        # List to load into: allowlist, denylist, or doubtlist
+    format: "json"           # Wire format: json
+    source: "mqtt"           # Fetch method: mqtt, file, or xfr
+    topic: "tapir/feed/blocklist"
+    validatorkey: "/etc/dnstapir/validator.key"
+    bootstrap:
       - "https://bootstrap.example.com/feed"
     bootstrapurl: "https://bootstrap.example.com"
-    bootstrapkey: "path/to/bootstrap.key"
+    bootstrapkey: "/etc/dnstapir/bootstrap.key"
 
-  example-file-source:
+  # Local domain list (plain text, one domain per line)
+  local-allowlist:
     active: true
-    name: "example-file-source"
-    description: "Example local file source"
-    type: "file"
-    format: "rpz"
-    source: "local"
-    filename: "/etc/pop/blocklist.rpz"  # Local file path (file sources only)
-    immutable: false                     # If true, source will not be updated
+    name: "local-allowlist"
+    description: "Locally managed allowlist"
+    type: "allowlist"
+    format: "domains"        # File format: domains, csv, or dawg
+    source: "file"
+    filename: "/etc/dnstapir/allowlist.txt"
+    immutable: false         # If true, the list is never updated at runtime
 
+  # RPZ zone transfer feed
+  upstream-rpz:
+    active: true
+    name: "upstream-rpz"
+    description: "Upstream RPZ denylist via zone transfer"
+    type: "denylist"
+    format: "rpz"
+    source: "xfr"
+    upstream: "192.0.2.1:53"
+    zone: "blocklist.example.com."
+```
+
+### Field reference
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `active` | yes | Enable this source |
+| `name` | yes | Source identifier |
+| `description` | yes | Human-readable description |
+| `type` | yes | Target list: `allowlist`, `denylist`, or `doubtlist` |
+| `format` | yes | Data format. For `source: mqtt`: `json`. For `source: file`: `domains`, `csv`, or `dawg`. For `source: xfr`: `rpz` |
+| `source` | yes | Fetch method: `mqtt`, `file`, or `xfr` |
+| `topic` | no | MQTT topic to subscribe to (`source: mqtt` only) |
+| `validatorkey` | no | Path to the key used to verify signed MQTT messages |
+| `bootstrap` | no | List of bootstrap server URLs for initial data load (`source: mqtt` only) |
+| `bootstrapurl` | no | Bootstrap server base URL |
+| `bootstrapkey` | no | Path to the bootstrap authentication key |
+| `filename` | no | Path to the local file (`source: file` only) |
+| `immutable` | no | If `true`, the list is never refreshed at runtime (default: `false`) |
+| `upstream` | no | Upstream DNS server address `host:port` for zone transfer (`source: xfr` only) |
+| `zone` | no | Zone name to transfer (`source: xfr` only) |
+
+**Note on `type: allowlist` with DAWG format:** DAWG files are only supported for `type: allowlist`.
+
+---
+
+## pop-outputs.yaml
+
+Outputs define downstream DNS resolvers that receive RPZ NOTIFY and can perform AXFR/IXFR.
+
+```yaml
+outputs:
+  downstream-resolver:
+    active: true
+    name: "downstream-resolver"
+    description: "Primary downstream DNS resolver"
+    type: "doubtlist"
+    format: "rpz"
+    downstream: "192.0.2.10:53"
+```
+
+### Field reference
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `active` | yes | Enable this output |
+| `name` | yes | Output identifier |
+| `description` | yes | Human-readable description |
+| `type` | yes | Source list type this output is derived from |
+| `format` | yes | Output format (`rpz`) |
+| `downstream` | yes | Downstream resolver address `host:port` to send DNS NOTIFY to |
+
+---
+
+## pop-policy.yaml
+
+Policy rules determine what RPZ action is applied to names found in each list.
+
+```yaml
 policy:
-  logfile: "/var/log/pop-policy.log"   # Optional policy log file
+  logfile: "/var/log/dnstapir/pop-policy.log"
   allowlist:
-    action: "accept"          # Action for allowlisted domains
+    action: "allowlist"
   denylist:
-    action: "drop"            # Action for denylisted domains
+    action: "nxdomain"
   doubtlist:
     numsources:
-      limit: 3                # Block if domain seen in this many sources
-      action: "drop"
+      limit: 3
+      action: "nxdomain"
     numtapirtags:
-      limit: 2                # Block if domain has this many TAPIR tags
+      limit: 2
       action: "drop"
     denytapir:
-      tags:                   # Block if domain has any of these TAPIR tags
+      tags:
         - "malware"
         - "phishing"
       action: "drop"
 ```
 
-## Required Fields
+### Field reference
 
-All fields are required unless marked as optional.
+| Field | Required | Description |
+|-------|----------|-------------|
+| `policy.logfile` | no | Policy decision log file path |
+| `policy.allowlist.action` | yes | Action for allowlisted names |
+| `policy.denylist.action` | yes | Action for denylisted names |
+| `policy.doubtlist.numsources.limit` | yes | Block if a name appears in this many or more doubtlist sources |
+| `policy.doubtlist.numsources.action` | yes | Action when `numsources.limit` is reached |
+| `policy.doubtlist.numtapirtags.limit` | yes | Block if a name carries this many or more TAPIR tags |
+| `policy.doubtlist.numtapirtags.action` | yes | Action when `numtapirtags.limit` is reached |
+| `policy.doubtlist.denytapir.tags` | yes | Block if a name carries any of these TAPIR tags |
+| `policy.doubtlist.denytapir.action` | yes | Action when a tag in `denytapir.tags` is matched |
 
-| Section | Field | Required | Description |
-|---------|-------|----------|-------------|
-| log | file | ✅ | Log file path |
-| log | verbose | ✅ | Enable verbose logging |
-| log | debug | ✅ | Enable debug logging |
-| services.rpz | zonename | ✅ | RPZ zone name |
-| services.rpz | serialcache | ✅ | Serial cache file path |
-| services.reaper | interval | ✅ | Cleanup interval in seconds |
-| apiserver | active | ✅ | Enable API server |
-| apiserver | name | ✅ | API server name |
-| apiserver | key | ✅ | API authentication key |
-| apiserver | addresses | ✅ | HTTP listen addresses |
-| apiserver | tlsaddresses | ✅ | HTTPS listen addresses |
-| dnsengine | active | ✅ | Enable DNS engine |
-| dnsengine | name | ✅ | DNS engine name |
-| dnsengine | addresses | ✅ | DNS listen addresses |
-| dnsengine | logfile | ✅ | DNS engine log file |
-| bootstrapserver | active | ✅ | Enable bootstrap server |
-| bootstrapserver | name | ✅ | Bootstrap server name |
-| bootstrapserver | addresses | ✅ | HTTP listen addresses |
-| bootstrapserver | tlsaddresses | ✅ | HTTPS listen addresses |
-| bootstrapserver | logfile | ➖ | Log file path (optional) |
-| keystore | path | ✅ | Path to keystore file (must exist) |
-| sources.* | active | ✅ | Enable this source |
-| sources.* | name | ✅ | Source name |
-| sources.* | description | ✅ | Source description |
-| sources.* | type | ✅ | Source type: `mqtt` or `file` |
-| sources.* | format | ✅ | Data format: `json` or `rpz` |
-| sources.* | source | ✅ | Source connection string |
-| sources.* | topic | ➖ | MQTT topic (mqtt sources only) |
-| sources.* | filename | ➖ | Local file path (file sources only) |
-| sources.* | immutable | ➖ | Prevent source updates (optional, default: false) |
-| sources.* | validatorkey | ➖ | Path to validator key (optional) |
-| sources.* | bootstrap | ➖ | Bootstrap URLs (optional) |
-| sources.* | bootstrapurl | ➖ | Bootstrap server URL (optional) |
-| sources.* | bootstrapkey | ➖ | Bootstrap key path (optional) |
-| policy | logfile | ➖ | Policy log file (optional) |
-| policy.allowlist | action | ✅ | Action for allowlisted domains |
-| policy.denylist | action | ✅ | Action for denylisted domains |
-| policy.doubtlist.numsources | limit | ✅ | Source count threshold |
-| policy.doubtlist.numsources | action | ✅ | Action when threshold exceeded |
-| policy.doubtlist.numtapirtags | limit | ✅ | TAPIR tag count threshold |
-| policy.doubtlist.numtapirtags | action | ✅ | Action when threshold exceeded |
-| policy.doubtlist.denytapir | tags | ✅ | TAPIR tags that trigger denial |
-| policy.doubtlist.denytapir | action | ✅ | Action for matched tags |
+### Valid action values
+
+| Value | RPZ effect |
+|-------|-----------|
+| `allowlist` or `passthru` | `rpz-passthru.` — allow the name through |
+| `nxdomain` | `.` — return NXDOMAIN |
+| `nodata` | `*.` — return NODATA |
+| `drop` | `rpz-drop.` — silently drop the query |
+| `redirect` | redirect (target TBD in upstream config) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -303,7 +303,7 @@ File-based sources (`source: file`) support three formats, set via the `format` 
 
 Plain text, one fully-qualified domain name per line. Lines are read as-is and converted to FQDN (trailing dot appended if missing).
 
-```
+```text
 example.com
 malicious.example.org
 blocked.test.
@@ -313,7 +313,7 @@ blocked.test.
 
 CSV file with a header row (skipped) and the domain name in the **second column** (index 1).
 
-```
+```csv
 id,domain,category
 1,malicious.example.com,malware
 2,phishing.example.org,phishing

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,122 @@
+# POP Configuration Guide
+
+POP uses a YAML configuration file. Below is a complete example with explanations for each field.
+
+## Example Configuration
+
+```yaml
+log:
+  file: "/var/log/pop.log"    # Path to log file
+  verbose: false               # Enable verbose logging
+  debug: false                 # Enable debug logging
+
+services:
+  rpz:
+    zonename: "rpz.example.com."   # RPZ zone name
+    serialcache: "/var/cache/pop/serial.cache"  # Path to serial cache file
+  reaper:
+    interval: 3600   # Cleanup interval in seconds
+
+apiserver:
+  active: true
+  name: "pop-api"
+  key: "your-api-key"
+  addresses:                   # HTTP listen addresses
+    - "127.0.0.1:8080"
+  tlsaddresses:                # HTTPS listen addresses
+    - "0.0.0.0:8443"
+
+dnsengine:
+  active: true
+  name: "pop-dns"
+  addresses:
+    - "127.0.0.1:53"
+  logfile: "/var/log/pop-dns.log"
+
+bootstrapserver:
+  active: false
+  name: "pop-bootstrap"
+  addresses:
+    - "127.0.0.1:9090"
+  tlsaddresses:
+    - "0.0.0.0:9443"
+  logfile: "/var/log/pop-bootstrap.log"
+
+keystore:
+  path: "/etc/pop/keystore.json"   # Path to keystore file (must exist)
+
+sources:
+  example-mqtt-source:
+    active: true
+    name: "example-mqtt-source"
+    description: "Example MQTT intelligence source"
+    type: "mqtt"              # Source type: mqtt, file, etc.
+    format: "json"            # Data format
+    source: "mqtt://broker.example.com"
+    topic: "tapir/feed/blocklist"
+    validatorkey: "path/to/validator.key"
+    bootstrap:
+      - "https://bootstrap.example.com/feed"
+    bootstrapurl: "https://bootstrap.example.com"
+    bootstrapkey: "path/to/bootstrap.key"
+
+  example-file-source:
+    active: true
+    name: "example-file-source"
+    description: "Example local file source"
+    type: "file"
+    format: "rpz"
+    source: "local"
+    filename: "/etc/pop/blocklist.rpz"
+    immutable: false          # If true, source will not be updated
+
+policy:
+  logfile: "/var/log/pop-policy.log"
+  allowlist:
+    action: "accept"          # Action for allowlisted domains: accept
+  denylist:
+    action: "drop"            # Action for denylisted domains: drop
+  doubtlist:
+    numsources:
+      limit: 3                # Block if seen in this many sources
+      action: "drop"
+    numtapirtags:
+      limit: 2                # Block if has this many TAPIR tags
+      action: "drop"
+    denytapir:
+      tags:                   # Block if domain has any of these tags
+        - "malware"
+        - "phishing"
+      action: "drop"
+```
+
+## Required Fields
+
+All fields marked below are required unless stated otherwise.
+
+| Section | Field | Required | Description |
+|---------|-------|----------|-------------|
+| log | file | ✅ | Log file path |
+| log | verbose | ✅ | Verbose logging toggle |
+| log | debug | ✅ | Debug logging toggle |
+| services.rpz | zonename | ✅ | RPZ zone name |
+| services.rpz | serialcache | ✅ | Serial cache file path |
+| services.reaper | interval | ✅ | Reaper interval in seconds |
+| apiserver | active | ✅ | Enable API server |
+| apiserver | name | ✅ | API server name |
+| apiserver | key | ✅ | API authentication key |
+| apiserver | addresses | ✅ | HTTP listen addresses |
+| apiserver | tlsaddresses | ✅ | HTTPS listen addresses |
+| dnsengine | active | ✅ | Enable DNS engine |
+| dnsengine | name | ✅ | DNS engine name |
+| dnsengine | addresses | ✅ | DNS listen addresses |
+| dnsengine | logfile | ✅ | DNS engine log file |
+| keystore | path | ✅ | Path to keystore file (must exist) |
+| sources.* | active | ✅ | Enable this source |
+| sources.* | name | ✅ | Source name |
+| sources.* | description | ✅ | Source description |
+| sources.* | type | ✅ | Source type (mqtt, file, etc.) |
+| sources.* | format | ✅ | Data format (json, rpz, etc.) |
+| sources.* | source | ✅ | Source connection string |
+| policy.allowlist | action | ✅ | Action for allowlisted domains |
+| policy.denylist | action | ✅ | Action for denylisted domains |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,20 +4,21 @@ POP loads configuration from four separate YAML files at startup, all located in
 
 | File | Purpose |
 |------|---------|
-| `dnstapir-pop.yaml` | Main config: logging, services, API/DNS/bootstrap servers, keystore |
+| `tapir-pop.yaml` | Main config: logging, services, API/DNS/bootstrap servers, keystore, TAPIR/MQTT |
 | `pop-sources.yaml` | Intelligence sources (MQTT, file, RPZ zone transfer) |
 | `pop-outputs.yaml` | RPZ downstream outputs |
 | `pop-policy.yaml` | Policy rules for allow/deny/doubtlist decisions |
 
 ---
 
-## dnstapir-pop.yaml
+## tapir-pop.yaml
 
 ```yaml
 log:
+  mode: "debug"            # "debug" enables debug logging; any other value disables it
   file: "/var/log/dnstapir/pop.log"
-  verbose: false
-  debug: false
+  verbose: false           # Forwarded to the sources library
+  debug: false             # Forwarded to the sources library
 
 services:
   rpz:
@@ -25,6 +26,20 @@ services:
     serialcache: "/var/cache/dnstapir/pop-serial.yaml"
   reaper:
     interval: 3600
+  refreshengine:
+    active: true           # Enable the periodic RPZ refresh engine
+
+# Note: a few legacy keys live under the singular "service:" key (not "services:")
+service:
+  reset_soa_serial: false  # If true, reset RPZ SOA serial on startup
+  maxrefresh: 3600         # Upper bound (seconds) for refresh interval
+
+tapir:
+  config:
+    active: true           # Enable receiving TAPIR global config over MQTT
+    topic: "tapir/config"  # MQTT topic for global config updates
+  mqtt:
+    logfile: "/var/log/dnstapir/pop-mqtt.log"
 
 apiserver:
   active: true
@@ -59,12 +74,19 @@ keystore:
 
 | Field | Required | Description |
 |-------|----------|-------------|
+| `log.mode` | no | Set to `"debug"` to enable debug logging in POP itself |
 | `log.file` | yes | Log file path |
-| `log.verbose` | yes | Enable verbose logging |
-| `log.debug` | yes | Enable debug logging |
+| `log.verbose` | no | Forwarded to the sources library to enable verbose source logging |
+| `log.debug` | no | Forwarded to the sources library to enable debug source logging |
 | `services.rpz.zonename` | yes | RPZ zone name served to downstream resolvers |
 | `services.rpz.serialcache` | yes | File where the current RPZ serial is persisted across restarts |
 | `services.reaper.interval` | yes | Interval in seconds for the cleanup (reaper) goroutine |
+| `services.refreshengine.active` | yes | Enable the periodic RPZ refresh engine |
+| `service.reset_soa_serial` | no | Reset the RPZ SOA serial on startup (note: singular `service`, not `services`) |
+| `service.maxrefresh` | no | Upper bound in seconds applied to refresh intervals (note: singular `service`) |
+| `tapir.config.active` | no | Enable receiving TAPIR global config updates via MQTT |
+| `tapir.config.topic` | required when `tapir.config.active: true` | MQTT topic carrying TAPIR global config |
+| `tapir.mqtt.logfile` | no | Dedicated log file for TAPIR MQTT traffic |
 | `apiserver.active` | yes | Enable the REST API server |
 | `apiserver.name` | yes | API server identifier |
 | `apiserver.key` | yes | API authentication key |
@@ -97,6 +119,7 @@ sources:
     type: "doubtlist"        # List to load into: allowlist, denylist, or doubtlist
     format: "json"           # Wire format: json
     source: "mqtt"           # Fetch method: mqtt, file, or xfr
+    immutable: false         # MQTT-only: if true, ignore TAPIR global config updates
     topic: "tapir/feed/blocklist"
     validatorkey: "/etc/dnstapir/validator.key"
     bootstrap:
@@ -113,7 +136,6 @@ sources:
     format: "domains"        # File format: domains, csv, or dawg
     source: "file"
     filename: "/etc/dnstapir/allowlist.txt"
-    immutable: false         # If true, the list is never updated at runtime
 
   # RPZ zone transfer feed
   upstream-rpz:
@@ -143,7 +165,7 @@ sources:
 | `bootstrapurl` | no | Bootstrap server base URL (`source: mqtt` only) |
 | `bootstrapkey` | no | Path to the bootstrap authentication key (`source: mqtt` only) |
 | `filename` | required when `source: file` | Path to the local file |
-| `immutable` | no | If `true`, the list is never refreshed at runtime (default: `false`) |
+| `immutable` | no | MQTT sources only: if `true`, the source ignores TAPIR global config updates that would otherwise replace it. Has no effect on `file` or `xfr` sources |
 | `upstream` | required when `source: xfr` | Upstream DNS server address `host:port` for zone transfer |
 | `zone` | required when `source: xfr` | Zone name to transfer |
 
@@ -226,7 +248,8 @@ policy:
 | `nxdomain` | `.` — return NXDOMAIN |
 | `nodata` | `*.` — return NODATA |
 | `drop` | `rpz-drop.` — silently drop the query |
-| `redirect` | redirect (target TBD in upstream config) |
+
+> Note: a `redirect` action exists in the codebase but is not fully implemented — it currently maps to a placeholder CNAME target, and the doubtlist AXFR path does not handle it. Avoid using `redirect` until upstream support lands.
 
 ### Policy examples
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -153,13 +153,13 @@ sources:
 
 ## pop-outputs.yaml
 
-Outputs define downstream DNS resolvers that receive RPZ NOTIFY and can perform AXFR/IXFR.
+Outputs define downstream DNS resolvers that receive DNS NOTIFY messages and can perform DNS AXFR/IXFR zone transfers.
 
 ```yaml
 outputs:
-  downstream-resolver:
+  primary-resolver:
     active: true
-    name: "downstream-resolver"
+    name: "primary-resolver"
     description: "Primary downstream DNS resolver"
     type: "doubtlist"
     format: "rpz"
@@ -174,7 +174,7 @@ outputs:
 | `name` | yes | Output identifier |
 | `description` | yes | Human-readable description |
 | `type` | yes | Source list type this output is derived from |
-| `format` | yes | Output format (`rpz`) |
+| `format` | yes | Output format: `rpz` (currently the only supported format) |
 | `downstream` | yes | Downstream resolver address `host:port` to send DNS NOTIFY to |
 
 ---


### PR DESCRIPTION
Closes #145

Added docs/configuration.md with:
- Complete configuration example with all fields
- Field descriptions and required/optional annotations
- Reference table for all configuration sections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive POP configuration guide with full YAML examples and per-file field reference tables covering startup configuration, logging, services, servers, keystore, sources, outputs, and policy rules.
  * Documented policy behavior with valid RPZ action values, note on partial redirect support, and three end-to-end examples (Strict, Permissive, Silent drop).
  * Described supported source file formats (domains, CSV, DAWG), CSV parsing rules, and DAWG limitations (allowlist-only, built from a sorted domain list, loaded at startup).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dnstapir/pop/pull/146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->