### PR TITLE
Unify doubtlist policy into a single decide() function (#156)

### DIFF
--- a/lists.go
+++ b/lists.go
@@ -6,6 +6,10 @@ package main
 
 import (
 	"fmt"
+	"strings"
+
+	"github.com/dnstapir/tapir"
+	"github.com/miekg/dns"
 )
 
 // Allowlisted / Denylisted / Doubtlisted are thin membership predicates over
@@ -17,20 +21,53 @@ func (pd *PopData) Allowlisted(name string) bool { return len(pd.listOf("allowli
 func (pd *PopData) Denylisted(name string) bool  { return len(pd.listOf("denylist", name)) > 0 }
 func (pd *PopData) Doubtlisted(name string) bool { return len(pd.listOf("doubtlist", name)) > 0 }
 
-func (pd *PopData) DoubtlistingReport(name string) (bool, string) {
-	var report string
-	// 	if len(pd.Doubtlists) == 0 {
-	if len(pd.Lists["doubtlist"]) == 0 {
-		return false, fmt.Sprintf("Domain name \"%s\" is not doubtlisted (there are no active doubtlists).\n", name)
-	}
+// LookupReport explains the RPZ decision for a name using the SAME decide()
+// path that builds the served zone, so the explanation can never disagree with
+// what is actually served (AXFR/IXFR). It reports the emitted action, the
+// deciding stage, the matching sources, and (for doubtlist decisions) which
+// rules fired. This is the minimal unification; the richer structured output
+// for the "filter reason" CLI command (task a) is built on the same Reason.
+func (pd *PopData) LookupReport(name string) string {
+	action, reason := pd.decide(name)
+	fqdn := dns.Fqdn(name)
 
-	// 	for _, list := range pd.Doubtlists {
-	for _, list := range pd.Lists["doubtlist"] {
-		pd.Logger.Printf("Doubtlisted: checking %s in doubtlist %s", name, list.Name)
-		report += fmt.Sprintf("Domain name \"%s\" could be present in doubtlist %s\n", name, list.Name)
+	var b strings.Builder
+	switch reason.Stage {
+	case StageAllowlist:
+		fmt.Fprintf(&b, "Domain name %q is allowlisted (sources: %s); not filtered.\n",
+			fqdn, sourceNames(reason.Sources))
+	case StageDenylist:
+		fmt.Fprintf(&b, "Domain name %q is denylisted (sources: %s); served as %s.\n",
+			fqdn, sourceNames(reason.Sources), tapir.ActionToString[action])
+	case StageDoubtlist:
+		if action == tapir.ALLOWLIST {
+			fmt.Fprintf(&b, "Domain name %q is in doubtlists (sources: %s) but no rule triggered; not filtered.\n",
+				fqdn, sourceNames(reason.Sources))
+		} else {
+			fmt.Fprintf(&b, "Domain name %q is doubtlisted (sources: %s); served as %s.\n",
+				fqdn, sourceNames(reason.Sources), tapir.ActionToString[action])
+			for _, rr := range reason.Fired {
+				fmt.Fprintf(&b, "  rule %q fired: %s (action %s)\n",
+					rr.Rule, rr.Detail, tapir.ActionToString[rr.Action])
+			}
+		}
+	default: // StageNone
+		fmt.Fprintf(&b, "Domain name %q is not present in any list; not filtered.\n", fqdn)
 	}
-	return false, report
+	return b.String()
+}
 
+// sourceNames renders the source names of a set of ListHits, in the (already
+// sorted) order listOf produced.
+func sourceNames(hits []ListHit) string {
+	if len(hits) == 0 {
+		return "(none)"
+	}
+	names := make([]string, 0, len(hits))
+	for _, h := range hits {
+		names = append(names, h.Source)
+	}
+	return strings.Join(names, ", ")
 }
 
 func (pd *PopData) DoubtlistAdd(name, policy, source string) (string, error) {

--- a/lists.go
+++ b/lists.go
@@ -6,71 +6,16 @@ package main
 
 import (
 	"fmt"
-	"log"
-
-	//	"github.com/smhanov/dawg"
-	"github.com/dnstapir/tapir"
 )
 
-func (pd *PopData) Allowlisted(name string) bool {
-	for _, list := range pd.Lists["allowlist"] {
-		switch list.Format {
-		case "dawg":
-			if tapir.GlobalCF.Debug {
-				pd.Logger.Printf("Allowlisted: DAWG: checking %s in allowlist %s", name, list.Name)
-			}
-			if list.Dawgf.IndexOf(name) != -1 {
-				return true
-			}
-		case "map":
-			if tapir.GlobalCF.Debug {
-				pd.Logger.Printf("Allowlisted: MAP: checking %s in allowlist %s", name, list.Name)
-			}
-			if _, exists := list.Names[name]; exists {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func (pd *PopData) Denylisted(name string) bool {
-	for _, list := range pd.Lists["denylist"] {
-		if tapir.GlobalCF.Debug {
-			pd.Logger.Printf("Denylisted: checking %s in Denylist %s", name, list.Name)
-		}
-		switch list.Format {
-		case "dawg":
-			if list.Dawgf.IndexOf(name) != -1 {
-				return true
-			}
-		case "map":
-			if _, exists := list.Names[name]; exists {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func (pd *PopData) Doubtlisted(name string) bool {
-	for _, list := range pd.Lists["doubtlist"] {
-		if tapir.GlobalCF.Debug {
-			pd.Logger.Printf("Doubtlisted: checking %s in doubtlist %s", name, list.Name)
-		}
-		switch list.Format {
-		case "map":
-			if _, exists := list.Names[name]; exists {
-				return true
-			}
-			//		case "trie":
-			//			return list.Trie.Search(name) != nil
-		default:
-			log.Fatalf("Unknown doubtlist format %s", list.Format)
-		}
-	}
-	return false
-}
+// Allowlisted / Denylisted / Doubtlisted are thin membership predicates over
+// the single listOf() lookup (defined in policy.go). They previously each
+// re-implemented the same per-format scan; Doubtlisted additionally crashed
+// the daemon (log.Fatalf) on an unknown list format, which listOf() now
+// degrades to a logged skip.
+func (pd *PopData) Allowlisted(name string) bool { return len(pd.listOf("allowlist", name)) > 0 }
+func (pd *PopData) Denylisted(name string) bool  { return len(pd.listOf("denylist", name)) > 0 }
+func (pd *PopData) Doubtlisted(name string) bool { return len(pd.listOf("doubtlist", name)) > 0 }
 
 func (pd *PopData) DoubtlistingReport(name string) (bool, string) {
 	var report string

--- a/policy.go
+++ b/policy.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -209,6 +210,10 @@ func (pd *PopData) listOf(class, name string) []ListHit {
 			pd.Logger.Printf("listOf: skipping source %q: unknown format %q", src, list.Format)
 		}
 	}
+	// Sort by source name so the result (and therefore Reason.Sources) is
+	// deterministic — pd.Lists is a map, so iteration order is randomized.
+	// This upholds the "same inputs -> same (Action, Reason)" invariant.
+	sort.Slice(hits, func(i, j int) bool { return hits[i].Source < hits[j].Source })
 	return hits
 }
 

--- a/policy.go
+++ b/policy.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net"
 	"os"
@@ -103,85 +104,223 @@ func (pd *PopData) ParseOutputs() error {
 	return nil
 }
 
-// Note: we onlygethere when we know that this name is only doubtlisted
-// so no need tocheckfor allow- or denylisting
-func (pd *PopData) ComputeRpzDoubtlistAction(name string) tapir.Action {
+// ---------------------------------------------------------------------------
+// Unified policy engine (issue #156).
+//
+// decide() is the single decision function used by BOTH the RPZ compilation
+// (GenerateRpzAxfr/Ixfr) and any lookup/explain path, so the served zone and
+// an explanation of it can never disagree. It returns the emitted Action plus
+// a Reason that records why, which is also the substrate for the future
+// "filter reason" CLI command.
+//
+// Invariants (objectives a + b in the design doc; these are NOT provisional):
+//   1. Allowlist is absolute: a name on any allowlist is never in the output.
+//   2. Order independence: source declaration / map iteration order must not
+//      affect the result.
+//   3. Determinism: same inputs -> same (Action, Reason).
+//
+// The doubtlist rules themselves ARE provisional (a future policy language),
+// so they are expressed as a slice of pluggable rules rather than an if-ladder:
+// adding a knob is one entry + one test, removing one is a deletion.
+// ---------------------------------------------------------------------------
 
-	var doubtHits = map[string]*tapir.TapirName{}
-	for listname, list := range pd.Lists["doubtlist"] {
+// Stage records which precedence level made the decision.
+type Stage int
+
+const (
+	StageNone Stage = iota // not in any list
+	StageAllowlist
+	StageDenylist
+	StageDoubtlist
+)
+
+func (s Stage) String() string {
+	switch s {
+	case StageAllowlist:
+		return "allowlist"
+	case StageDenylist:
+		return "denylist"
+	case StageDoubtlist:
+		return "doubtlist"
+	default:
+		return "none"
+	}
+}
+
+// ListHit is one source (of a given list class) that contained the name.
+// Entry is nil for dawg-format lists, which support membership but not
+// per-name metadata.
+type ListHit struct {
+	Source string
+	Entry  *tapir.TapirName
+}
+
+// RuleResult is the outcome of evaluating one doubtlist rule.
+type RuleResult struct {
+	Rule   string // "numsources" | "numtapirtags" | "denytapir"
+	Fired  bool
+	Action tapir.Action
+	Detail string // human-readable explanation, e.g. "in 3 sources (limit 2)"
+}
+
+// Reason is the structured explanation returned alongside the action.
+type Reason struct {
+	Action  tapir.Action
+	Stage   Stage
+	Sources []ListHit    // sources (of the deciding stage) that contained the name
+	Fired   []RuleResult // doubt rules that fired (only when Stage == StageDoubtlist)
+	Winner  *RuleResult  // the fired rule whose action was emitted (nil if none fired)
+}
+
+// actionSeverity ranks actions from most to least restrictive. mostRestrictive
+// picks the highest. Defined as a single ordered table so the ranking is a
+// one-line change if operators push back (e.g. on REDIRECT's placement).
+// ALLOWLIST is the "no action / passthru" value (note: tapir.Action is a
+// bitmask and tapir.PASSTHRU is a distinct unused bit; the codebase uses
+// ALLOWLIST as the pass value, matching the old ComputeRpzAction).
+var actionSeverity = map[tapir.Action]int{
+	tapir.DROP:      5,
+	tapir.NXDOMAIN:  4,
+	tapir.NODATA:    3,
+	tapir.REDIRECT:  2,
+	tapir.ALLOWLIST: 1,
+}
+
+// listOf returns every source in the given class that contains name. This is
+// the single membership-lookup helper that replaces the former
+// Allowlisted/Denylisted/Doubtlisted trio. Order-independent: it scans all
+// sources and the caller does not rely on iteration order.
+func (pd *PopData) listOf(class, name string) []ListHit {
+	var hits []ListHit
+	for src, list := range pd.Lists[class] {
 		switch list.Format {
-		case "map":
-			if v, exists := list.Names[name]; exists {
-				// pd.Logger.Printf("ComputeRpzDoubtlistAction: found %s in doubtlist %s (%d names)",
-				// 	name, listname, len(list.Names))
-				doubtHits[listname] = &v
+		case "dawg":
+			if list.Dawgf.IndexOf(name) != -1 {
+				hits = append(hits, ListHit{Source: src})
 			}
-			//		case "trie":
-			//			if list.Trie.Search(name) != nil {
-			//				doubtHits = append(doubtHits, v)
-			//			}
+		case "map":
+			if e, ok := list.Names[name]; ok {
+				e := e // copy; don't alias the map value
+				hits = append(hits, ListHit{Source: src, Entry: &e})
+			}
 		default:
-			POPExiter("Unknown doubtlist format %s", list.Format)
+			// Degrade, never crash a long-running daemon on a bad list format
+			// (was log.Fatalf in the old Doubtlisted()). See issue #6.
+			pd.Logger.Printf("listOf: skipping source %q: unknown format %q", src, list.Format)
 		}
 	}
-	if len(doubtHits) >= pd.Policy.Doubtlist.NumSources {
-		pd.Policy.Logger.Printf("ComputeRpzDoubtlistAction: name %s is in %d or more sources, action is %s",
-			name, pd.Policy.Doubtlist.NumSources, tapir.ActionToString[pd.Policy.Doubtlist.NumSourcesAction])
-		return pd.Policy.Doubtlist.NumSourcesAction
-	}
-	pd.Policy.Logger.Printf("ComputeRpzDoubtlistAction: name %s is in %d sources, not enough for action", name, len(doubtHits))
-
-	if _, exists := doubtHits["dns-tapir"]; exists {
-		numtapirtags := doubtHits["dns-tapir"].TagMask.NumTags()
-		if numtapirtags >= pd.Policy.Doubtlist.NumTapirTags {
-			pd.Policy.Logger.Printf("ComputeRpzDoubtlistAction: name %s has more than %d tapir tags, action is %s",
-				name, pd.Policy.Doubtlist.NumTapirTags, tapir.ActionToString[pd.Policy.Doubtlist.NumTapirTagsAction])
-			return pd.Policy.Doubtlist.NumTapirTagsAction
-		}
-		pd.Policy.Logger.Printf("ComputeRpzDoubtlistAction: name %s has %d tapir tags, not enough for action", name, numtapirtags)
-	}
-	pd.Policy.Logger.Printf("ComputeRpzDoubtlistAction: name %s is present in %d doubtlists, but does not trigger any action",
-		name, len(doubtHits))
-	return pd.Policy.AllowlistAction
+	return hits
 }
 
-// Decision to block a doubtlisted name:
-// 1. More than N tags present
-// 2. Name is present in more than M sources
-// 3. Name
-
-func ApplyDoubtPolicy(name string, v *tapir.TapirName) string {
-	var rpzaction string
-	if v.HasAction(tapir.NXDOMAIN) {
-		rpzaction = "."
-	} else if v.HasAction(tapir.NODATA) {
-		rpzaction = "*."
-	} else if v.HasAction(tapir.DROP) {
-		rpzaction = "rpz-drop."
-	} else if v.TagMask != 0 {
-		log.Printf("there are tags")
-		rpzaction = "rpz-drop."
-	}
-
-	return rpzaction
+// doubtRule is a single pluggable doubtlist rule.
+type doubtRule struct {
+	name string
+	eval func(hits []ListHit, p DoubtlistPolicy) RuleResult
 }
 
-func (pd *PopData) ComputeRpzAction(name string) tapir.Action {
-	if pd.Allowlisted(name) {
-		if pd.Debug {
-			pd.Policy.Logger.Printf("ComputeRpzAction: name %s is doubtlisted, action is %s", name, tapir.ActionToString[pd.Policy.AllowlistAction])
+// doubtRules is the ordered set of rules evaluated for a doubtlisted name.
+// This release ships exactly the three knobs documented in pop-policy.yaml.
+// To add a future knob, append a rule here and a test row in policy_test.go.
+var doubtRules = []doubtRule{
+	{
+		name: "numsources",
+		eval: func(hits []ListHit, p DoubtlistPolicy) RuleResult {
+			r := RuleResult{Rule: "numsources"}
+			if len(hits) >= p.NumSources {
+				r.Fired, r.Action = true, p.NumSourcesAction
+				r.Detail = fmt.Sprintf("in %d sources (limit %d)", len(hits), p.NumSources)
+			}
+			return r
+		},
+	},
+	{
+		name: "numtapirtags",
+		eval: func(hits []ListHit, p DoubtlistPolicy) RuleResult {
+			// Counts tags on the dns-tapir source's entry ONLY (Q2). A future
+			// "numtags" rule could count the merged tag set across sources.
+			r := RuleResult{Rule: "numtapirtags"}
+			if e := dnsTapirEntry(hits); e != nil {
+				if n := e.TagMask.NumTags(); n >= p.NumTapirTags {
+					r.Fired, r.Action = true, p.NumTapirTagsAction
+					r.Detail = fmt.Sprintf("dns-tapir entry has %d tags (limit %d)", n, p.NumTapirTags)
+				}
+			}
+			return r
+		},
+	},
+	{
+		name: "denytapir",
+		eval: func(hits []ListHit, p DoubtlistPolicy) RuleResult {
+			// Fires when the dns-tapir entry carries any tag in DenyTapirTags.
+			// Newly wired in: parsed from config today but never consulted.
+			// Default DenyTapirTags is empty, so this is a no-op until set.
+			r := RuleResult{Rule: "denytapir"}
+			if p.DenyTapirTags == 0 {
+				return r
+			}
+			if e := dnsTapirEntry(hits); e != nil && e.TagMask&p.DenyTapirTags != 0 {
+				r.Fired, r.Action = true, p.DenyTapirAction
+				r.Detail = "dns-tapir entry carries a denytapir tag"
+			}
+			return r
+		},
+	},
+}
+
+// dnsTapirEntry returns the TapirName from the special "dns-tapir" source among
+// the hits, or nil if that source did not contain the name (or had no entry,
+// e.g. a dawg list).
+func dnsTapirEntry(hits []ListHit) *tapir.TapirName {
+	for _, h := range hits {
+		if h.Source == "dns-tapir" {
+			return h.Entry
 		}
-		return pd.Policy.AllowlistAction
-	} else if pd.Denylisted(name) {
-		if pd.Debug {
-			pd.Policy.Logger.Printf("ComputeRpzAction: name %s is denylisted, action is %s", name, tapir.ActionToString[pd.Policy.DenylistAction])
-		}
-		return pd.Policy.DenylistAction
-	} else if pd.Doubtlisted(name) {
-		if pd.Debug {
-			pd.Policy.Logger.Printf("ComputeRpzAction: name %s is doubtlisted, needs further evaluation to determine action", name)
-		}
-		return pd.ComputeRpzDoubtlistAction(name) // This is not complete, only a placeholder for now.
 	}
-	return tapir.ALLOWLIST
+	return nil
+}
+
+// decide is the single source of truth for the policy decision on a name.
+func (pd *PopData) decide(name string) (tapir.Action, Reason) {
+	// Stage 1: allowlist is absolute (invariant 1).
+	if hits := pd.listOf("allowlist", name); len(hits) > 0 {
+		return pd.Policy.AllowlistAction, Reason{
+			Action: pd.Policy.AllowlistAction, Stage: StageAllowlist, Sources: hits,
+		}
+	}
+
+	// Stage 2: denylist.
+	if hits := pd.listOf("denylist", name); len(hits) > 0 {
+		return pd.Policy.DenylistAction, Reason{
+			Action: pd.Policy.DenylistAction, Stage: StageDenylist, Sources: hits,
+		}
+	}
+
+	// Stage 3: doubtlist (provisional, pluggable rules).
+	hits := pd.listOf("doubtlist", name)
+	if len(hits) == 0 {
+		return tapir.ALLOWLIST, Reason{Action: tapir.ALLOWLIST, Stage: StageNone}
+	}
+
+	var fired []RuleResult
+	for _, rule := range doubtRules {
+		if r := rule.eval(hits, pd.Policy.Doubtlist); r.Fired {
+			fired = append(fired, r)
+		}
+	}
+
+	if len(fired) == 0 {
+		// In one or more doubtlists, but no rule triggered -> passthru.
+		return tapir.ALLOWLIST, Reason{Action: tapir.ALLOWLIST, Stage: StageDoubtlist, Sources: hits}
+	}
+
+	// Conflict resolution: most-restrictive action wins (order-independent).
+	winner := &fired[0]
+	for i := 1; i < len(fired); i++ {
+		if actionSeverity[fired[i].Action] > actionSeverity[winner.Action] {
+			winner = &fired[i]
+		}
+	}
+	return winner.Action, Reason{
+		Action: winner.Action, Stage: StageDoubtlist, Sources: hits, Fired: fired, Winner: winner,
+	}
 }

--- a/policy_test.go
+++ b/policy_test.go
@@ -29,6 +29,7 @@ package main
 
 import (
 	"log"
+	"strings"
 	"testing"
 
 	"github.com/dnstapir/tapir"
@@ -263,12 +264,29 @@ func TestDecideOrderIndependence(t *testing.T) {
 		listFixture{"doubtlist", "alpha", []tapir.TapirName{tn(q, 0, 0)}},
 	)
 
-	actA, _ := a.decide(q)
-	actB, _ := b.decide(q)
+	actA, reasonA := a.decide(q)
+	actB, reasonB := b.decide(q)
 	if actA != actB {
 		t.Errorf("decide is order-dependent: %s vs %s",
 			tapir.ActionToString[actA], tapir.ActionToString[actB])
 	}
+	// Reason.Sources must also be order-independent: listOf sorts by source
+	// name, so both insertion orders must yield the same sequence (alpha, zeta).
+	if got := sourceList(reasonA.Sources); got != "alpha,zeta" {
+		t.Errorf("reasonA.Sources = %q, want alpha,zeta", got)
+	}
+	if sourceList(reasonA.Sources) != sourceList(reasonB.Sources) {
+		t.Errorf("Reason.Sources order depends on insertion order: %q vs %q",
+			sourceList(reasonA.Sources), sourceList(reasonB.Sources))
+	}
+}
+
+func sourceList(hits []ListHit) string {
+	var ss []string
+	for _, h := range hits {
+		ss = append(ss, h.Source)
+	}
+	return strings.Join(ss, ",")
 }
 
 // --- TestDecideDeterminism -------------------------------------------------
@@ -282,12 +300,18 @@ func TestDecideDeterminism(t *testing.T) {
 		listFixture{"doubtlist", "other", []tapir.TapirName{tn(q, 0, 0)}},
 	)
 
-	first, _ := pd.decide(q)
+	first, firstReason := pd.decide(q)
+	firstSources := sourceList(firstReason.Sources)
 	for i := 0; i < 100; i++ {
-		got, _ := pd.decide(q)
+		got, gotReason := pd.decide(q)
 		if got != first {
 			t.Fatalf("decide is non-deterministic: call %d gave %s, first gave %s",
 				i, tapir.ActionToString[got], tapir.ActionToString[first])
+		}
+		// Reason.Sources ordering must be stable too (listOf sorts).
+		if gs := sourceList(gotReason.Sources); gs != firstSources {
+			t.Fatalf("Reason.Sources non-deterministic: call %d gave %q, first gave %q",
+				i, gs, firstSources)
 		}
 	}
 }

--- a/policy_test.go
+++ b/policy_test.go
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+
+package main
+
+// This is the first test file in the POP codebase, so a short orientation on
+// the Go testing machinery (no third-party framework is involved):
+//
+//   - A test file must end in `_test.go`. It is compiled ONLY when running
+//     `go test`, never into the normal binary, so test-only helpers here do
+//     not bloat the daemon.
+//   - It shares the package (`package main`) with the code under test, so it
+//     can reach unexported identifiers like `decide`, `PopData`, `Reason`.
+//     (The alternative, `package main_test`, would only see exported names.)
+//   - Any function `func TestXxx(t *testing.T)` is a test. Run them with
+//     `go test ./pop/`. The `*testing.T` is how a test reports failure:
+//       t.Errorf(...)  -> mark failed, keep going (good for table rows)
+//       t.Fatalf(...)  -> mark failed, stop THIS test immediately
+//   - `t.Run(name, func)` creates a named SUBTEST. Each table row becomes its
+//     own subtest, so a failure prints e.g. `TestDecide/numsources_at_limit`
+//     and you can re-run just that row with `-run 'TestDecide/numsources'`.
+//
+// The style below is "table-driven": the test cases are DATA (a slice of
+// structs), and one loop drives them all. This is idiomatic Go and is exactly
+// why the policy engine is the right first target — decide() is almost a pure
+// function (name + in-memory lists + policy config -> action), so a case is
+// just "given these lists and this policy, expect this action".
+
+import (
+	"log"
+	"testing"
+
+	"github.com/dnstapir/tapir"
+)
+
+// --- fixture helpers -------------------------------------------------------
+//
+// These build a minimal PopData carrying only what decide() needs: the Lists
+// map, the Policy, and a Logger. No config files, no MQTT, no DNS server.
+
+// tn is a terse constructor for a TapirName with a set of tags and an action.
+func tn(name string, tags tapir.TagMask, action tapir.Action) tapir.TapirName {
+	return tapir.TapirName{Name: name, TagMask: tags, Action: action}
+}
+
+// listFixture describes one source list to install into a PopData.
+type listFixture struct {
+	class  string // "allowlist" | "denylist" | "doubtlist"
+	source string // source name, e.g. "dns-tapir"
+	names  []tapir.TapirName
+}
+
+// newTestPopData assembles a PopData from a default policy plus a set of list
+// fixtures. The policy mirrors the documented pop-policy.yaml template.
+func newTestPopData(policy DoubtlistPolicy, fixtures ...listFixture) *PopData {
+	pd := &PopData{
+		Lists:  map[string]map[string]*tapir.WBGlist{},
+		Logger: log.Default(),
+	}
+	pd.Lists["allowlist"] = map[string]*tapir.WBGlist{}
+	pd.Lists["denylist"] = map[string]*tapir.WBGlist{}
+	pd.Lists["doubtlist"] = map[string]*tapir.WBGlist{}
+
+	pd.Policy = PopPolicy{
+		Logger:          log.Default(),
+		AllowlistAction: tapir.ALLOWLIST,
+		DenylistAction:  tapir.NODATA, // per the config template
+		Doubtlist:       policy,
+	}
+
+	for _, f := range fixtures {
+		names := map[string]tapir.TapirName{}
+		for _, n := range f.names {
+			names[n.Name] = n
+		}
+		pd.Lists[f.class][f.source] = &tapir.WBGlist{
+			Name:   f.source,
+			Type:   f.class,
+			Format: "map",
+			Names:  names,
+		}
+	}
+	return pd
+}
+
+// defaultDoubtPolicy matches the pop-policy.yaml template:
+//
+//	numsources:   {limit: 2, action: NXDOMAIN}
+//	numtapirtags: {limit: 3, action: NXDOMAIN}
+//	denytapir:    {tags: [likelymalware], action: REDIRECT}
+func defaultDoubtPolicy() DoubtlistPolicy {
+	return DoubtlistPolicy{
+		NumSources:         2,
+		NumSourcesAction:   tapir.NXDOMAIN,
+		NumTapirTags:       3,
+		NumTapirTagsAction: tapir.NXDOMAIN,
+		DenyTapirTags:      tapir.LikelyMalware,
+		DenyTapirAction:    tapir.REDIRECT,
+	}
+}
+
+// --- TestDecide ------------------------------------------------------------
+//
+// The core table-driven test. Each row sets up lists, runs decide(), and
+// asserts the emitted action AND which precedence stage made the decision.
+
+func TestDecide(t *testing.T) {
+	const q = "evil.example."
+
+	tests := []struct {
+		name       string // subtest name
+		fixtures   []listFixture
+		policy     DoubtlistPolicy
+		wantAction tapir.Action
+		wantStage  Stage
+	}{
+		{
+			// INVARIANT 1: allowlist is absolute. A name on an allowlist is
+			// never in the output, even if it is ALSO on a denylist and a
+			// doubtlist that would otherwise block it.
+			name: "allowlist beats deny and doubt",
+			fixtures: []listFixture{
+				{"allowlist", "corp-allow", []tapir.TapirName{tn(q, 0, 0)}},
+				{"denylist", "blocky", []tapir.TapirName{tn(q, 0, 0)}},
+				{"doubtlist", "a", []tapir.TapirName{tn(q, 0, 0)}},
+				{"doubtlist", "b", []tapir.TapirName{tn(q, 0, 0)}},
+			},
+			policy:     defaultDoubtPolicy(),
+			wantAction: tapir.ALLOWLIST,
+			wantStage:  StageAllowlist,
+		},
+		{
+			name: "denylist only -> DenylistAction",
+			fixtures: []listFixture{
+				{"denylist", "blocky", []tapir.TapirName{tn(q, 0, 0)}},
+			},
+			policy:     defaultDoubtPolicy(),
+			wantAction: tapir.NODATA, // == DenylistAction
+			wantStage:  StageDenylist,
+		},
+		{
+			// numsources threshold is 2: one source is below it.
+			name: "doubt in 1 source, below numsources -> passthru",
+			fixtures: []listFixture{
+				{"doubtlist", "a", []tapir.TapirName{tn(q, 0, 0)}},
+			},
+			policy:     defaultDoubtPolicy(),
+			wantAction: tapir.ALLOWLIST, // not included in output
+			wantStage:  StageDoubtlist,
+		},
+		{
+			name: "doubt in 2 sources, at numsources limit -> NumSourcesAction",
+			fixtures: []listFixture{
+				{"doubtlist", "a", []tapir.TapirName{tn(q, 0, 0)}},
+				{"doubtlist", "b", []tapir.TapirName{tn(q, 0, 0)}},
+			},
+			policy:     defaultDoubtPolicy(),
+			wantAction: tapir.NXDOMAIN,
+			wantStage:  StageDoubtlist,
+		},
+		{
+			// numtapirtags: 3 tags on the dns-tapir entry, limit is 3 -> fires.
+			name: "dns-tapir entry with >= numtapirtags tags -> NumTapirTagsAction",
+			fixtures: []listFixture{
+				{"doubtlist", "dns-tapir", []tapir.TapirName{
+					tn(q, tapir.BadIP|tapir.CdnTracker|tapir.HighVolume, 0),
+				}},
+			},
+			policy:     defaultDoubtPolicy(),
+			wantAction: tapir.NXDOMAIN,
+			wantStage:  StageDoubtlist,
+		},
+		{
+			// Q2 GUARD: the same 3 tags on a NON-dns-tapir source must NOT
+			// trigger numtapirtags (it counts dns-tapir tags only). One source,
+			// below numsources too, so it should pass through.
+			name: "3 tags on non-dns-tapir source does not fire numtapirtags",
+			fixtures: []listFixture{
+				{"doubtlist", "somefeed", []tapir.TapirName{
+					tn(q, tapir.BadIP|tapir.CdnTracker|tapir.HighVolume, 0),
+				}},
+			},
+			policy:     defaultDoubtPolicy(),
+			wantAction: tapir.ALLOWLIST,
+			wantStage:  StageDoubtlist,
+		},
+		{
+			// denytapir: dns-tapir entry carries LikelyMalware, which is in
+			// DenyTapirTags -> REDIRECT. Only one source and only one tag, so
+			// neither numsources nor numtapirtags fires; denytapir is the only
+			// firing rule.
+			name: "dns-tapir entry with denytapir tag -> DenyTapirAction",
+			fixtures: []listFixture{
+				{"doubtlist", "dns-tapir", []tapir.TapirName{
+					tn(q, tapir.LikelyMalware, 0),
+				}},
+			},
+			policy:     defaultDoubtPolicy(),
+			wantAction: tapir.REDIRECT,
+			wantStage:  StageDoubtlist,
+		},
+		{
+			// CONFLICT RESOLUTION: most-restrictive wins.
+			// In 2 sources -> numsources fires (NXDOMAIN). The dns-tapir entry
+			// also carries a denytapir tag -> denytapir fires (REDIRECT).
+			// Ranking DROP > NXDOMAIN > NODATA > REDIRECT > PASSTHRU means
+			// NXDOMAIN (more restrictive) wins over REDIRECT.
+			name: "numsources(NXDOMAIN) vs denytapir(REDIRECT) -> NXDOMAIN wins",
+			fixtures: []listFixture{
+				{"doubtlist", "dns-tapir", []tapir.TapirName{tn(q, tapir.LikelyMalware, 0)}},
+				{"doubtlist", "other", []tapir.TapirName{tn(q, 0, 0)}},
+			},
+			policy:     defaultDoubtPolicy(),
+			wantAction: tapir.NXDOMAIN,
+			wantStage:  StageDoubtlist,
+		},
+		{
+			// not in any list -> passthru, decided at the "none" stage.
+			name:       "unknown name -> passthru (stage none)",
+			fixtures:   []listFixture{},
+			policy:     defaultDoubtPolicy(),
+			wantAction: tapir.ALLOWLIST,
+			wantStage:  StageNone,
+		},
+	}
+
+	for _, tc := range tests {
+		// tc captured per-iteration; t.Run makes each row an isolated subtest.
+		t.Run(tc.name, func(t *testing.T) {
+			pd := newTestPopData(tc.policy, tc.fixtures...)
+			gotAction, gotReason := pd.decide(q)
+			if gotAction != tc.wantAction {
+				t.Errorf("decide(%q) action = %s, want %s",
+					q, tapir.ActionToString[gotAction], tapir.ActionToString[tc.wantAction])
+			}
+			if gotReason.Stage != tc.wantStage {
+				t.Errorf("decide(%q) stage = %v, want %v", q, gotReason.Stage, tc.wantStage)
+			}
+		})
+	}
+}
+
+// --- TestDecideOrderIndependence -------------------------------------------
+//
+// INVARIANT 2: the result must not depend on source ordering. We build the
+// same logical doubtlist set under different source names/insertion patterns
+// and assert the action is identical. (Go already randomizes map iteration
+// order between runs, so a hidden iteration-order dependence would also show
+// up here as flakiness.)
+
+func TestDecideOrderIndependence(t *testing.T) {
+	const q = "evil.example."
+	policy := defaultDoubtPolicy()
+
+	// Two sources, names inserted in two different orders. numsources(2) fires.
+	a := newTestPopData(policy,
+		listFixture{"doubtlist", "alpha", []tapir.TapirName{tn(q, 0, 0)}},
+		listFixture{"doubtlist", "zeta", []tapir.TapirName{tn(q, 0, 0)}},
+	)
+	b := newTestPopData(policy,
+		listFixture{"doubtlist", "zeta", []tapir.TapirName{tn(q, 0, 0)}},
+		listFixture{"doubtlist", "alpha", []tapir.TapirName{tn(q, 0, 0)}},
+	)
+
+	actA, _ := a.decide(q)
+	actB, _ := b.decide(q)
+	if actA != actB {
+		t.Errorf("decide is order-dependent: %s vs %s",
+			tapir.ActionToString[actA], tapir.ActionToString[actB])
+	}
+}
+
+// --- TestDecideDeterminism -------------------------------------------------
+//
+// INVARIANT 3: same inputs -> same output, every call.
+
+func TestDecideDeterminism(t *testing.T) {
+	const q = "evil.example."
+	pd := newTestPopData(defaultDoubtPolicy(),
+		listFixture{"doubtlist", "dns-tapir", []tapir.TapirName{tn(q, tapir.LikelyMalware, 0)}},
+		listFixture{"doubtlist", "other", []tapir.TapirName{tn(q, 0, 0)}},
+	)
+
+	first, _ := pd.decide(q)
+	for i := 0; i < 100; i++ {
+		got, _ := pd.decide(q)
+		if got != first {
+			t.Fatalf("decide is non-deterministic: call %d gave %s, first gave %s",
+				i, tapir.ActionToString[got], tapir.ActionToString[first])
+		}
+	}
+}

--- a/refreshengine.go
+++ b/refreshengine.go
@@ -384,24 +384,9 @@ func (pd *PopData) RefreshEngine(conf *Config, stopch chan struct{}) {
 
 			case "RPZ-LOOKUP":
 				log.Printf("RefreshEngine: recieved an RPZ LOOKUP command: %s", cmd.Domain)
-				var msg string
-				if pd.Allowlisted(cmd.Domain) {
-					resp.Msg = fmt.Sprintf("Domain name \"%s\" is allowlisted.", cmd.Domain)
-					cmd.Result <- resp
-					continue
-				}
-				msg += fmt.Sprintf("Domain name \"%s\" is not allowlisted.\n", cmd.Domain)
-
-				if pd.Denylisted(cmd.Domain) {
-					resp.Msg = fmt.Sprintf("Domain name \"%s\" is denylisted.", cmd.Domain)
-					cmd.Result <- resp
-					continue
-				}
-				msg += fmt.Sprintf("Domain name \"%s\" is not denylisted.\n", cmd.Domain)
-
-				// if the name isn't either allowlisted or denylisted: go though all doubtlists
-				_, doubtmsg := pd.DoubtlistingReport(cmd.Domain)
-				resp.Msg = msg + doubtmsg
+				// Explain via the same decide() path that builds the served
+				// zone, so the lookup verdict can never disagree with AXFR/IXFR.
+				resp.Msg = pd.LookupReport(cmd.Domain)
 				cmd.Result <- resp
 				continue
 

--- a/rpz.go
+++ b/rpz.go
@@ -54,35 +54,28 @@ func (pd *PopData) GenerateRpzAxfr() error {
 	pd.DenylistedNames = deny
 	pd.Logger.Printf("GenRpzAxfr: There are a total of %d Denylisted names in the sources", len(deny))
 
+	// Collect the candidate set of doubtlisted names. A name that is also
+	// denylisted is already handled by the denylist; allowlisted names are
+	// excluded by decide() below (allowlist is absolute), so the per-name
+	// decision is deferred to the emission loop where decide() is the single
+	// authority on both inclusion and action.
 	for gname, glist := range pd.Lists["doubtlist"] {
 		pd.Logger.Printf("---> GenRpzAxfr: working on doubtlist %s (%d names)",
 			gname, len(glist.Names))
 		switch glist.Format {
 		case "map":
 			for k, v := range glist.Names {
-				// pd.Logger.Printf("Adding name %s from doubtlist %s to tentative output.", k, gname)
 				if _, exists := pd.DenylistedNames[k]; exists {
-					// pd.Logger.Printf("Doubtlisted name %s is also denylisted. No need to add twice.", k)
-				} else if pd.Allowlisted(k) {
-					// pd.Logger.Printf("Doubtlisted name %s is also allowlisted. Dropped from output.", k)
+					continue // already covered by the denylist
+				}
+				if existing, exists := doubt[k]; exists {
+					// Same name in several doubtlists: merge tags/actions.
+					// Order-independent because OR is commutative.
+					existing.TagMask |= v.TagMask
+					existing.Action |= v.Action
 				} else {
-					// pd.Logger.Printf("Doubtlisted name %s is not allowlisted. Evalutate inclusion in output.", k)
-					action := pd.ComputeRpzAction(k)
-					if action == tapir.ALLOWLIST {
-						// pd.Logger.Printf("Doubtlisted name %s is not included in output.", k)
-					} else {
-						// pd.Logger.Printf("Doubtlisted name %s is included in output.", k)
-
-						if _, exists := doubt[k]; exists {
-							// pd.Logger.Printf("Doubt name %s already in output. Combining tags and actions.", k)
-							tmp := doubt[k]
-							tmp.TagMask = doubt[k].TagMask | v.TagMask
-							tmp.Action = tmp.Action | v.Action
-							doubt[k] = tmp
-						} else {
-							doubt[k] = &v
-						}
-					}
+					v := v // copy; don't alias the map value
+					doubt[k] = &v
 				}
 			}
 		default:
@@ -90,10 +83,8 @@ func (pd *PopData) GenerateRpzAxfr() error {
 		}
 	}
 	pd.DoubtlistedNames = doubt
-	pd.Logger.Printf("GenRpzAxfr: There are a total of %d doubtlisted names in the sources", len(doubt))
+	pd.Logger.Printf("GenRpzAxfr: There are a total of %d candidate doubtlisted names in the sources", len(doubt))
 
-	// newaxfrdata := []*tapir.RpzName{}
-	// pd.Rpz.RpzMap = map[string]*tapir.RpzName{}
 	for name := range pd.DenylistedNames {
 		cname := new(dns.CNAME)
 		cname.Hdr = dns.RR_Header{
@@ -110,39 +101,39 @@ func (pd *PopData) GenerateRpzAxfr() error {
 			RR:     &rr,
 			Action: pd.Policy.DenylistAction,
 		}
-		// newaxfrdata = append(newaxfrdata, &rpzn)
-		// pd.Rpz.RpzMap[nname+pd.Rpz.ZoneName] = &rpzn
 		pd.mu.Lock()
 		pd.Rpz.Axfr.Data[name+pd.Rpz.ZoneName] = &rpzn
 		pd.mu.Unlock()
 	}
 
-	for name, v := range pd.DoubtlistedNames {
-		rpzaction := ApplyDoubtPolicy(name, v)
-
-		if rpzaction != "" {
-			cname := new(dns.CNAME)
-			cname.Hdr = dns.RR_Header{
-				Name:     name + pd.Rpz.ZoneName,
-				Rrtype:   dns.TypeCNAME,
-				Class:    dns.ClassINET,
-				Ttl:      3600,
-				Rdlength: 1,
-			}
-			cname.Target = rpzaction // XXX: wrong
-			rr := dns.RR(cname)
-
-			rpzn := tapir.RpzName{
-				Name:   name,
-				RR:     &rr,
-				Action: pd.Policy.DenylistAction, // XXX: naa
-			}
-			// newaxfrdata = append(newaxfrdata, &rpzn)
-			// pd.Rpz.RpzMap[name+pd.Rpz.ZoneName] = &rpzn
-			pd.mu.Lock()
-			pd.Rpz.Axfr.Data[name+pd.Rpz.ZoneName] = &rpzn
-			pd.mu.Unlock()
+	for name := range pd.DoubtlistedNames {
+		// decide() is the single source of truth: it enforces allowlist
+		// precedence and applies the (provisional) doubtlist policy. A name
+		// that does not earn an action passes through and is not emitted.
+		action, _ := pd.decide(name)
+		if action == tapir.ALLOWLIST {
+			continue
 		}
+
+		cname := new(dns.CNAME)
+		cname.Hdr = dns.RR_Header{
+			Name:     name + pd.Rpz.ZoneName,
+			Rrtype:   dns.TypeCNAME,
+			Class:    dns.ClassINET,
+			Ttl:      3600,
+			Rdlength: 1,
+		}
+		cname.Target = tapir.ActionToCNAMETarget[action]
+		rr := dns.RR(cname)
+
+		rpzn := tapir.RpzName{
+			Name:   name,
+			RR:     &rr,
+			Action: action,
+		}
+		pd.mu.Lock()
+		pd.Rpz.Axfr.Data[name+pd.Rpz.ZoneName] = &rpzn
+		pd.mu.Unlock()
 	}
 
 	//	pd.Rpz.Axfr.Data = pd.Rpz.RpzMap
@@ -186,7 +177,7 @@ func (pd *PopData) GenerateRpzIxfr(data *tapir.TapirMsg) (RpzIxfr, error) {
 		tn.Name = dns.Fqdn(tn.Name)
 		pd.Policy.Logger.Printf("GenerateRpzIxfr: evaluating removed name %s", tn.Name)
 		if cur, exist := pd.Rpz.Axfr.Data[tn.Name]; exist {
-			newAction := pd.ComputeRpzAction(tn.Name)
+			newAction, _ := pd.decide(tn.Name)
 			oldAction := cur.Action
 			if newAction != oldAction {
 				if pd.Debug {
@@ -232,7 +223,7 @@ func (pd *PopData) GenerateRpzIxfr(data *tapir.TapirMsg) (RpzIxfr, error) {
 		tn.Name = dns.Fqdn(tn.Name)
 		pd.Policy.Logger.Printf("GenerateRpzIxfr: evaluating added name %s", tn.Name)
 		addtorpz = false
-		newAction := pd.ComputeRpzAction(tn.Name)
+		newAction, _ := pd.decide(tn.Name)
 		if cur, exist := pd.Rpz.Axfr.Data[tn.Name]; exist {
 			if newAction == tapir.ALLOWLIST {
 				// delete from rpz


### PR DESCRIPTION
## What

Replaces POP's three disagreeing doubtlist decision paths with a single `decide(name) -> (Action, Reason)` used by both RPZ compilation and lookup, so the served zone and an explanation of it can never diverge.

## Why

Today there are three decision points (issue #156):

- `ComputeRpzAction` / `ComputeRpzDoubtlistAction` — threshold model, used at lookup, explicitly marked "placeholder".
- `ApplyDoubtPolicy` — an "any tag -> drop" path that can return `""` and silently drop a name.
- `GenerateRpzAxfr` — calls **both** contradictorily and stores a hardcoded-wrong `Action` (the `// XXX: wrong` / `// XXX: naa` markers).

So a name's presence in the served zone can disagree with what a lookup reports, and the allowlist-absolute guarantee was half-commented-out.

## How

One `decide()` is now the single authority. Design doc: `docs/2026-06-02-pop-156-policy-engine-design.md`.

**Invariants — hard-enforced and tested** (these are *not* provisional):
- **Allowlist is absolute**: a name on any allowlist is never in the output (wins over deny + doubt).
- **Order independence**: source/map iteration order does not affect the result.
- **Determinism**.

**Doubtlist policy is deliberately provisional** (a future policy language), so it is a slice of pluggable rules rather than an if-ladder — adding a knob is one entry + one test:
- `numsources` (all doubtlist sources count)
- `numtapirtags` (**dns-tapir source only**; a future `numtags` could count merged tags)
- `denytapir` (**newly wired in** — parsed from config before but never consulted)

**Conflict resolution**: most-restrictive action wins, ranked `DROP > NXDOMAIN > NODATA > REDIRECT > PASSTHRU` (one ordered table; trivial to change).

The three former predicates (`Allowlisted`/`Denylisted`/`Doubtlisted`) now delegate to a single `listOf()` helper; the `log.Fatalf`-on-unknown-format crash path (reachable from a DNS query) degrades to a logged skip.

## Tests

Adds `pop/policy_test.go` — **the first test suite in this repo**. Table-driven `TestDecide` (allowlist-absolute, denylist, numsources thresholds, numtapirtags incl. the dns-tapir-only guard, denytapir, the most-restrictive conflict case, passthru), plus order-independence and determinism property tests. Passes under `-race`.

Note: `go test` is run with `-vet=off` locally because of pre-existing `go vet` format-string bugs in unrelated files (`configupdater.go`/`statusupdater.go`/`refreshengine.go`), tracked separately in #168.

Closes #156.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unknown doubtlist formats no longer cause service failures.
  * Policy conflict resolution now ensures deterministic and consistent outcomes with "most-restrictive action wins" ordering.

* **Tests**
  * Added comprehensive coverage for policy decision logic, including order-independence and determinism validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->