### PR TITLE
Fix pre-existing go vet format-string bugs (#168)

### DIFF
--- a/configupdater.go
+++ b/configupdater.go
@@ -43,7 +43,7 @@ func (pd *PopData) ConfigUpdater(conf *Config, stopch chan struct{}) {
 	log.Printf("ConfigUpdater: Starting")
 
 	for inbox := range ConfigChan {
-		log.Printf("ConfigUpdater: got config update message on topic %s: %v", inbox.Topic)
+		log.Printf("ConfigUpdater: got config update message on topic %s (%d bytes)", inbox.Topic, len(inbox.Payload))
 		var gconfig tapir.GlobalConfig
 		err = json.Unmarshal(inbox.Payload, &gconfig)
 		if err != nil {
@@ -58,58 +58,58 @@ func (pd *PopData) ConfigUpdater(conf *Config, stopch chan struct{}) {
 }
 
 func (pd *PopData) ProcessTapirGlobalConfig(gconfig tapir.GlobalConfig) {
-    log.Printf("TapirProcessGlobalConfig: %+v", gconfig)
+	log.Printf("TapirProcessGlobalConfig: %+v", gconfig)
 
-    // Assume there is only one topic and that it is the one we want
-    // TODO maybe sanitize or sanity check or something
-    newTopic := gconfig.ObservationTopics[0]
-    bootstrapServers := gconfig.Bootstrap.Servers
-    bootstrapUrl := gconfig.Bootstrap.BaseUrl
-    bootstrapKey := gconfig.Bootstrap.ApiToken
+	// Assume there is only one topic and that it is the one we want
+	// TODO maybe sanitize or sanity check or something
+	newTopic := gconfig.ObservationTopics[0]
+	bootstrapServers := gconfig.Bootstrap.Servers
+	bootstrapUrl := gconfig.Bootstrap.BaseUrl
+	bootstrapKey := gconfig.Bootstrap.ApiToken
 
 	//for _, listtype := range []string{"allowlist", "denylist", "doubtlist"} {
 	for _, wbgl := range pd.Lists["doubtlist"] {
-        if  wbgl.Immutable || wbgl.Datasource != "mqtt" {
-            continue
-        }
+		if wbgl.Immutable || wbgl.Datasource != "mqtt" {
+			continue
+		}
 
-        for _, topic := range wbgl.MqttDetails.Topics {
-            pd.MqttEngine.RemoveTopic(topic)
-            break // Only one topic
-        }
+		for _, topic := range wbgl.MqttDetails.Topics {
+			pd.MqttEngine.RemoveTopic(topic)
+			break // Only one topic
+		}
 
 		pd.mu.Lock()
-        wbgl.MqttDetails.Topics = append(wbgl.MqttDetails.Topics, newTopic.Topic)
-        wbgl.MqttDetails.Bootstrap = bootstrapServers
-        wbgl.MqttDetails.BootstrapUrl = bootstrapUrl
-        wbgl.MqttDetails.BootstrapKey = bootstrapKey
+		wbgl.MqttDetails.Topics = append(wbgl.MqttDetails.Topics, newTopic.Topic)
+		wbgl.MqttDetails.Bootstrap = bootstrapServers
+		wbgl.MqttDetails.BootstrapUrl = bootstrapUrl
+		wbgl.MqttDetails.BootstrapKey = bootstrapKey
 		pd.mu.Unlock()
 
-        err := pd.MqttEngine.SubToTopic(newTopic.Topic, pd.TapirObservations, "struct", true) // XXX: Brr. kludge.
-        if err != nil {
-            POPExiter("ProcessTapirGlobalConfig: Error adding topic %s: %v", newTopic, err)
-        }
+		err := pd.MqttEngine.SubToTopic(newTopic.Topic, pd.TapirObservations, "struct", true) // XXX: Brr. kludge.
+		if err != nil {
+			POPExiter("ProcessTapirGlobalConfig: Error adding topic %s: %v", newTopic, err)
+		}
 
-        src := SourceConf{
-            Bootstrap:    wbgl.MqttDetails.Bootstrap,
-            BootstrapUrl: wbgl.MqttDetails.BootstrapUrl,
-            BootstrapKey: wbgl.MqttDetails.BootstrapKey,
-            Name:         wbgl.Name,
-            Format:       wbgl.Format,
-        }
+		src := SourceConf{
+			Bootstrap:    wbgl.MqttDetails.Bootstrap,
+			BootstrapUrl: wbgl.MqttDetails.BootstrapUrl,
+			BootstrapKey: wbgl.MqttDetails.BootstrapKey,
+			Name:         wbgl.Name,
+			Format:       wbgl.Format,
+		}
 
-        if len(gconfig.Bootstrap.Servers) > 0 {
-            pd.Logger.Printf("ProcessTapirGlobalConfig: %d bootstrap servers advertised: %v", wbgl.Name, len(src.Bootstrap), src.Bootstrap)
-            tmp, err := pd.BootstrapMqttSource(src)
-            if err != nil {
-                pd.Logger.Printf("ProcessTapirGlobalConfig: Error bootstrapping MQTT source %s: %v", wbgl.Name, err)
-            } else {
-		        pd.mu.Lock()
-                *wbgl = *tmp
-		        pd.mu.Unlock()
-            }
-        }
+		if len(gconfig.Bootstrap.Servers) > 0 {
+			pd.Logger.Printf("ProcessTapirGlobalConfig: source %s: %d bootstrap servers advertised: %v", wbgl.Name, len(src.Bootstrap), src.Bootstrap)
+			tmp, err := pd.BootstrapMqttSource(src)
+			if err != nil {
+				pd.Logger.Printf("ProcessTapirGlobalConfig: Error bootstrapping MQTT source %s: %v", wbgl.Name, err)
+			} else {
+				pd.mu.Lock()
+				*wbgl = *tmp
+				pd.mu.Unlock()
+			}
+		}
 
 		pd.Logger.Printf("*** DONE Processing global config")
-    }
+	}
 }

--- a/refreshengine.go
+++ b/refreshengine.go
@@ -333,12 +333,12 @@ func (pd *PopData) RefreshEngine(conf *Config, stopch chan struct{}) {
 						}
 						resp.Msg = fmt.Sprintf("Zone %s: bumped serial from %d to %d. Notified downstreams: %v",
 							zone, resp.OldSerial, resp.NewSerial, rc.Downstreams)
-						log.Printf(resp.Msg)
+						log.Print(resp.Msg)
 						resp.Status = true
 					} else {
 						resp.Error = true
 						resp.ErrorMsg = fmt.Sprintf("Request to bump serial for unknown zone '%s'", zone)
-						log.Printf(resp.ErrorMsg)
+						log.Print(resp.ErrorMsg)
 					}
 				}
 				cmd.Result <- resp

--- a/statusupdater.go
+++ b/statusupdater.go
@@ -78,7 +78,7 @@ func (pd *PopData) StatusUpdater(conf *Config, stopch chan struct{}) {
 	if err != nil {
 		POPExiter("Error adding topic %s to MQTT Engine: %v", statusTopic, err)
 	}
-	pd.Logger.Printf("StatusUpdater: Topic status for MQTT engine %s: %+v", me.Creator)
+	pd.Logger.Printf("StatusUpdater: pub topic configured for MQTT engine %s", me.Creator)
 
 	_, outbox, _, err := me.StartEngine()
 	if err != nil {
@@ -132,7 +132,7 @@ func (pd *PopData) StatusUpdater(conf *Config, stopch chan struct{}) {
 					}
 					s.ComponentStatus[csu.Component] = comp
 					dirty = true
-					sur.Msg = fmt.Sprintf("StatusUpdater: %s report for known component: %s", csu.Status, csu.Component)
+					sur.Msg = fmt.Sprintf("StatusUpdater: %s report for known component: %s", tapir.StatusToString[csu.Status], csu.Component)
 				default:
 					log.Printf("StatusUpdater: %s report for unknown component: %s", tapir.StatusToString[csu.Status], csu.Component)
 					sur.Error = true
@@ -157,7 +157,7 @@ func (pd *PopData) StatusUpdater(conf *Config, stopch chan struct{}) {
 				}
 
 			default:
-				log.Printf("StatusUpdater: Unknown status: %s", csu.Status)
+				log.Printf("StatusUpdater: Unknown status: %s", tapir.StatusToString[csu.Status])
 			}
 		case <-stopch:
 			log.Printf("StatusUpdater: stopping")


### PR DESCRIPTION
## What

Fixes seven pre-existing `go vet` format-string bugs that were blocking `go test` from running with vet enabled.

## Why

`go test` runs `go vet` automatically; these failures made it abort before running any tests (the #156 PR had to use `-vet=off` as a workaround). Each is also a genuine latent logging bug. Tracked in #168.

## Fixes

- `configupdater.go:46` — `"%s: %v"` given only one arg → log topic + payload size.
- `configupdater.go:102` — `"%d ..."` given `wbgl.Name` (a string), args misaligned → add the source-name slot so `%d` gets the count.
- `statusupdater.go:81` — `"%+v"` given only one arg → drop the dangling verb.
- `statusupdater.go:135`, `:160` — `%s` on a `tapir.ComponentStatus` (a uint8, no Stringer) → render via `tapir.StatusToString[...]`.
- `refreshengine.go:336`, `:341` — `log.Printf(nonConstantString)` → `log.Print(...)`.

## Note on the diff size

`configupdater.go`'s `ProcessTapirGlobalConfig` was space-indented, so it also gets a `gofmt` pass — **most of that file's diff is whitespace normalization (space → tab), not logic.** The only logic changes in that file are lines 46 and 102.

## Verification

`go vet ./` clean, `go build ./...` green, `gofmt -l` clean. `go test ./` now runs with vet enabled (no `-vet=off`).

Closes #168.
